### PR TITLE
Fix assert being hit when querying without vector values

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+# Release Build Instructions
+
+To build and publish the PyPI package:
+
+1. `python -m pip install --upgrade build`
+1. `python -m pip install --upgrade twine`
+1. `rm -rf dist/`
+2. `python -m build`
+3. `python -m twine upload dist/*`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "turbopuffer"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python Client for accessing the turbopuffer API"
 authors = ["turbopuffer Inc. <info@turbopuffer.com>"]
 maintainers = ["Jacob Wirth"]

--- a/turbopuffer/namespace.py
+++ b/turbopuffer/namespace.py
@@ -14,6 +14,13 @@ class Namespace:
     backend: Backend
 
     def __init__(self, name: str, api_key: Optional[str] = None):
+        """
+        Creates a new turbopuffer.Namespace object for querying the turbopuffer API.
+
+        This function does not make any API calls on its own.
+
+        Specifying an api_key here will override the global configuration for API calls to this namespace.
+        """
         self.name = name
         self.backend = Backend(api_key)
 

--- a/turbopuffer/vectors.py
+++ b/turbopuffer/vectors.py
@@ -37,9 +37,7 @@ class VectorRow(JSONSerializable, str=False): # str=False to prevent JSON pretty
     def __post_init__(self):
         if not isinstance(self.id, int):
             raise ValueError('VectorRow.id must be an int, got:', type(self.id))
-        if self.vector is None and self.dist is None:
-            raise ValueError('VectorRow.vector cannot be None, use Namespace.delete([ids...]) instead.')
-        if not isinstance(self.vector, list) and self.dist is None:
+        if self.vector is not None and not isinstance(self.vector, list):
             raise ValueError('VectorRow.vector must be a list, got:', type(self.vector))
         if self.attributes is not None and not isinstance(self.attributes, dict):
             raise ValueError('VectorRow.attributes must be a dict, got:', type(self.attributes))

--- a/turbopuffer/version.py
+++ b/turbopuffer/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.1'
+VERSION = '0.1.2'


### PR DESCRIPTION
This was a redundant check to prevent upsert() to delete. A regression test is included.