### PR TITLE
fix: serialize numpy.float64 using orjson.dumps()

### DIFF
--- a/turbopuffer/__init__.py
+++ b/turbopuffer/__init__.py
@@ -5,7 +5,7 @@ upsert_batch_size = 5_000
 
 try:
     import orjson  # extras = ["fast"]
-    def dump_json_bytes(obj): return orjson.dumps(obj)
+    def dump_json_bytes(obj): return orjson.dumps(obj, option=orjson.OPT_SERIALIZE_NUMPY)
 except ImportError:
     import json
     def dump_json_bytes(obj): return json.dumps(obj).encode()


### PR DESCRIPTION
Serializing numpy objects requires the options to be passed explicitly as mentioned [here](https://github.com/ijl/orjson#numpy), otherwise the function `dump_json_bytes()` crashes with a `TypeError` if `orjson` is found.

This PR fixes this error.