### PR TITLE
String ID support

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
 import uuid
 
-test_prefix = f'{uuid.uuid1()}-'
+test_prefix = f'pytest-{uuid.uuid1()}-'

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -219,6 +219,22 @@ def test_query_vectors():
         check_result(row, expected[i])
         i += 1
 
+    # Test query with single filter
+    expected = [
+        tpuf.VectorRow(id=10),
+        tpuf.VectorRow(id=11),
+        tpuf.VectorRow(id=12),
+    ]
+    vector_set = ns.query(
+        top_k=3,
+        include_vectors=False,
+        filters={
+            'id': ['In', [10, 11, 12]]
+        },
+    )
+    for i in range(len(vector_set)):  # Use VectorResult in index mode
+        check_result(vector_set[i], expected[i])
+
     # Test query with no vectors
     expected = [
         tpuf.VectorRow(id=10),

--- a/turbopuffer/namespace.py
+++ b/turbopuffer/namespace.py
@@ -170,7 +170,7 @@ class Namespace:
               distance_metric: Optional[str] = None,
               top_k: int = 10,
               include_vectors: bool = False,
-              include_attributes: Optional[List[str]] = None,
+              include_attributes: Optional[Union[List[str], bool]] = None,
               filters: Optional[Dict[str, List[FilterTuple]]] = None) -> VectorResult:
         ...
 

--- a/turbopuffer/namespace.py
+++ b/turbopuffer/namespace.py
@@ -31,7 +31,7 @@ class Namespace:
         return f'tpuf-namespace:{self.name}'
 
     @overload
-    def upsert(self, ids: List[int], vectors: List[List[float]], attributes: Optional[Dict[str, List[Optional[str]]]] = None) -> None:
+    def upsert(self, ids: Union[List[int], List[str]], vectors: List[List[float]], attributes: Optional[Dict[str, List[Optional[str]]]] = None) -> None:
         """
         Creates or updates multiple vectors provided in a column-oriented layout.
         If this call succeeds, data is guaranteed to be durably written to object storage.
@@ -144,12 +144,12 @@ class Namespace:
 
         assert response.get('status', '') == 'OK', f'Invalid upsert() response: {response}'
 
-    def delete(self, ids: Union[int, List[int]]) -> None:
+    def delete(self, ids: Union[int, str, List[int], List[str]]) -> None:
         """
         Deletes vectors by id.
         """
 
-        if isinstance(ids, int):
+        if isinstance(ids, int) or isinstance(ids, str):
             response = self.backend.make_api_request('vectors', self.name, payload={
                 'ids': [ids],
                 'vectors': [None],

--- a/turbopuffer/query.py
+++ b/turbopuffer/query.py
@@ -41,8 +41,8 @@ class VectorQuery:
                     raise ValueError(f'VectorQuery.vector must a 1d-array, got {self.vector.ndim} dimensions')
             elif not isinstance(self.vector, list):
                 raise ValueError('VectorQuery.vector must be a list, got:', type(self.vector))
-        if self.include_attributes is not None and not isinstance(self.include_attributes, list):
-            raise ValueError('VectorQuery.include_attributes must be a list, got:', type(self.include_attributes))
+        if self.include_attributes is not None and not isinstance(self.include_attributes, list) and not isinstance(self.include_attributes, bool):
+            raise ValueError('VectorQuery.include_attributes must be a list or bool, got:', type(self.include_attributes))
         if self.filters is not None:
             if not isinstance(self.filters, dict):
                 raise ValueError('VectorQuery.filters must be a dict, got:', type(self.filters))

--- a/turbopuffer/query.py
+++ b/turbopuffer/query.py
@@ -43,5 +43,16 @@ class VectorQuery:
                 raise ValueError('VectorQuery.vector must be a list, got:', type(self.vector))
         if self.include_attributes is not None and not isinstance(self.include_attributes, list):
             raise ValueError('VectorQuery.include_attributes must be a list, got:', type(self.include_attributes))
-        if self.filters is not None and not isinstance(self.filters, dict):
-            raise ValueError('VectorQuery.filters must be a dict, got:', type(self.filters))
+        if self.filters is not None:
+            if not isinstance(self.filters, dict):
+                raise ValueError('VectorQuery.filters must be a dict, got:', type(self.filters))
+            else:
+                for name, filter in self.filters.items():
+                    if isinstance(filter, list):
+                        if len(filter) == 2 and isinstance(filter[0], str):
+                            # Support passing a single filter instead of a list
+                            self.filters[name] = [filter]
+                        elif len(filter) > 0 and not isinstance(filter[0], list):
+                            raise ValueError(f'VectorQuery.filters expected a list of filters for key {name}, got list of:', type(filter[0]))
+                    else:
+                        raise ValueError(f'VectorQuery.filters expected a list for key {name}, got:', type(filter))

--- a/turbopuffer/vectors.py
+++ b/turbopuffer/vectors.py
@@ -25,7 +25,7 @@ class VectorRow:
     If the VectorRow is a response from a query, it may also have a distance weighting.
     """
 
-    id: int
+    id: Union[int, str]
     vector: Optional[List[float]] = None
     attributes: Optional[Dict[str, Optional[str]]] = None
 
@@ -40,8 +40,8 @@ class VectorRow:
         )
 
     def __post_init__(self):
-        if not isinstance(self.id, int):
-            raise ValueError('VectorRow.id must be an int, got:', type(self.id))
+        if not isinstance(self.id, int) and not isinstance(self.id, str):
+            raise ValueError('VectorRow.id must be an int or str, got:', type(self.id))
         if self.vector is not None:
             if 'numpy' in sys.modules and isinstance(self.vector, sys.modules['numpy'].ndarray):
                 if self.vector.ndim != 1:
@@ -52,13 +52,15 @@ class VectorRow:
             raise ValueError('VectorRow.attributes must be a dict, got:', type(self.attributes))
 
     def __str__(self) -> str:
-        fields = [
-            f'id={self.id}',
-            f'vector={self.vector}',
-        ]
+        fields = []
+        if isinstance(self.id, int):
+            fields.append(f'id={self.id}')
+        else:
+            fields.append(f"id='{self.id}'")
+        fields.append(f'vector={self.vector}')
         if self.attributes:
             fields.append(f'attributes={self.attributes}')
-        if self.dist:
+        if self.dist is not None:
             fields.append(f'dist={self.dist}')
         return f"VectorRow({', '.join(fields)})"
 
@@ -71,7 +73,7 @@ class VectorColumns:
     If the VectorColumns is a response from a query, it may also have a set of distance weightings for each vector.
     """
 
-    ids: List[int]
+    ids: Union[List[int], List[str]]
     vectors: List[Optional[List[float]]]
     attributes: Optional[Dict[str, List[Optional[str]]]] = None
 


### PR DESCRIPTION
String ID support shipped today on the turbopuffer backend. This adds support for string IDs such as UUIDs.