### PR TITLE
upsert: add distance_metric on upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ if ns.exists():
 ns.upsert(
     ids=[1, 2],
     vectors=[[0.1, 0.2], [0.3, 0.4]],
-    attributes={'name': ['foo', 'foos']}
+    attributes={'name': ['foo', 'foos']},
+    distance_metric='cosine_distance',
 )
 
 # Alternatively, upsert using a row iterator
@@ -39,8 +40,9 @@ ns.upsert(
     {
         'id': id,
         'vector': [id/10, id/10],
-        'attributes': {'name': 'food'}
-    } for id in range(3, 10)
+        'attributes': {'name': 'food', 'num': 8}
+    } for id in range(3, 10),
+    distance_metric='cosine_distance',
 )
 
 # Query your dataset


### PR DESCRIPTION
Just do this part for now https://github.com/turbopuffer/turbopuffer-python/pull/16

You can now add a `distance_metric` to `upsert()`, which allows us to start maintaining an ANN index on the first upsert (rather than on the first query). Previously, we were unable to create an index while you're inserting, because we didn't know the distance metric.

@morgangallant @pushrax 