### PR TITLE
pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ orjson = {version = "^3.9", optional = true}
 numpy = {version = "^1.26.3", optional = true}
 pandas = {version = "^2.1.4", optional = true}
 
+
 [tool.poetry.extras]
 fast = ["orjson"]
 
@@ -44,6 +45,7 @@ optional = true
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.3"
 flake8 = "^7.0.0"
+pytest-xdist = "^3.6.1"
 
 [tool.poetry.group.compatibility]
 optional = true


### PR DESCRIPTION
Makes it possible to use the `pytest-xdist` plugin when running `poetry run pytest`.

The test codebase isn't very parallelizable right now unfortunately since the vector tests were all written in a way that each test implicitly depends on the side effects that the previous test didn't clean up, but at least we can parallelize based on test file (`--dist loadfile`).

Even without making the tests more parallelizable, this should already reduce the time it takes to run the python tests on CI by about 60-90 seconds (~3:00 instead of ~4:30 or so) based on what I've seen so far.