### PR TITLE
don't require /v1 suffix on api_base_url

### DIFF
--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -46,3 +46,9 @@ try:
     print('Loaded numpy tests')
 except ImportError:
     print('Skipped numpy tests')
+
+def test_base_url_compatibility():
+    assert tpuf.backend.clean_api_base_url("https://domain/v1/") == "https://domain"
+    assert tpuf.backend.clean_api_base_url("https://domain/v1") == "https://domain"
+    assert tpuf.backend.clean_api_base_url("https://domain/") == "https://domain"
+    assert tpuf.backend.clean_api_base_url("https://domain") == "https://domain"

--- a/turbopuffer/__init__.py
+++ b/turbopuffer/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 api_key = os.environ.get('TURBOPUFFER_API_KEY')
-api_base_url = os.environ.get('TURBOPUFFER_API_BASE_URL', 'https://api.turbopuffer.com/v1')
+api_base_url = os.environ.get('TURBOPUFFER_API_BASE_URL', 'https://api.turbopuffer.com')
 upsert_batch_size = 10_000
 max_retries = 6
 

--- a/turbopuffer/backend.py
+++ b/turbopuffer/backend.py
@@ -19,6 +19,12 @@ def find_api_key(api_key: Optional[str] = None) -> str:
                                   "Set the TURBOPUFFER_API_KEY environment variable, "
                                   "or pass `api_key=` when creating a Namespace.")
 
+def clean_api_base_url(base_url: str) -> str:
+    if base_url.endswith(('/v1', '/v1/', '/')):
+        return re.sub('(/v1|/v1/|/)$', '', base_url)
+    else:
+        return base_url
+
 
 class Backend:
     api_key: str
@@ -27,7 +33,7 @@ class Backend:
 
     def __init__(self, api_key: Optional[str] = None):
         self.api_key = find_api_key(api_key)
-        self.api_base_url = tpuf.api_base_url
+        self.api_base_url = clean_api_base_url(tpuf.api_base_url)
         self.session = requests.Session()
         self.session.headers.update({
             'Authorization': f'Bearer {self.api_key}',
@@ -48,7 +54,8 @@ class Backend:
         start = time.monotonic()
         if method is None and payload is not None:
             method = 'POST'
-        request = requests.Request(method or 'GET', self.api_base_url + '/' + '/'.join(args))
+
+        request = requests.Request(method or 'GET', self.api_base_url + '/v1/' + '/'.join(args))
 
         if query is not None:
             request.params = query


### PR DESCRIPTION
The API version should be hardcoded based on the client code, and not passed in by the user. Having it be configurable was a mistake. With this PR, users are not required to add /v1 to the base URL, which matches the typescript client. If /v1 or /v1/ is added by the user, it is now ignored (for backwards compatibility).