### PR TITLE
support id type in schema response

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -17,7 +17,10 @@ def test_schema():
         assert schema.get(attr).type == "?string"
         assert schema.get(attr).filterable
         assert schema.get(attr).full_text_search is None
-    
+
+    # TODO
+    # assert schema.get('id') == 'uint'
+
     # Write an update to the schema making 'hello' not filterable
     updated_hello_schema = tpuf.AttributeSchema(type="?string", filterable=False, full_text_search=None)
     updated_schema = ns.update_schema({

--- a/turbopuffer/namespace.py
+++ b/turbopuffer/namespace.py
@@ -57,11 +57,17 @@ class AttributeSchema:
         return result
 
 # Type alias for a namespace schema
-NamespaceSchema = Dict[str, AttributeSchema]
+# If the key is `id`, the value is a string representing the ID type,
+# otherwise the value is an AttributeSchema
+NamespaceSchema = Dict[str, Union[AttributeSchema, str]]
 
 def parse_namespace_schema(data: dict) -> NamespaceSchema:
     namespace_schema = {}
     for key, value in data.items():
+        if key == 'id':
+            namespace_schema[key] = value
+            continue
+
         fts_params = value.get('full_text_search')
         fts_instance = None
         if fts_params:


### PR DESCRIPTION
In preparation for adding the UUID ID type.

I'm not completely sure if it's better to return a bare string for the id, or return an object like we do for other attributes. None of the existing fields that apply to attributes make sense for the id, and I can't think of any other fields we'd want to include in the object.