### PR TITLE
fix recall, add region choosing to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ $ pip install turbopuffer[fast]
 ```py
 import turbopuffer as tpuf
 tpuf.api_key = 'your-token'  # Alternatively: export=TURBOPUFFER_API_KEY=your-token
+// Choose the best region for your data https://turbopuffer.com/docs/regions
+tpuf.api_base_url = "https://gcp-us-east4.turbopuffer.com"
 
 # Open a namespace
 ns = tpuf.Namespace('hello_world')

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -54,6 +54,9 @@ def test_upsert_rows():
     for i in range(10, 100):
         assert results[i-8] == tpuf.VectorRow(id=i, vector=[i/10, i/10], attributes={'test': 'rows'})
 
+    # Check to ensure recall is working
+    ns.recall()
+
 @pytest.mark.xdist_group(name="group1")
 def test_delete_vectors():
     ns = tpuf.Namespace(tests.test_prefix + 'client_test')

--- a/turbopuffer/namespace.py
+++ b/turbopuffer/namespace.py
@@ -440,8 +440,8 @@ class Namespace:
 
         response = self.backend.make_api_request('vectors', self.name, '_debug', 'recall', query={'num': num, 'top_k': top_k})
         content = response.get('content', dict())
-        assert 'recall' in content, f'Invalid recall() response: {response}'
-        return float(content.get('recall'))
+        assert 'avg_recall' in content, f'Invalid recall() response: {response}'
+        return float(content.get('avg_recall'))
 
 
 class NamespaceIterator:


### PR DESCRIPTION
@morgangallant a customer found that `recall()` fails after we renamed to `avg_recall` instead of just `recall`.

Also putting the region in the README, as that should really be chosen with care!