### PR TITLE
Add test to ensure 429 Too Many Requests is retried

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ For more details on request parameters and query options, check the docs at http
 
 ## Development
 
+Run `poetry install --with=test` to set up the project and dependencies.
+
 1. `poetry run pytest`
 2.  Bump version in `turbopuffer/version.py` and `pyproject.toml`
 3. `git tag vX.Y.Z && git push --tags`

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,44 @@
+import pytest
+import requests
+import time
+import turbopuffer as tpuf
+from turbopuffer import backend as tpuf_backend
+from unittest import mock
+
+
+def mock_response_returning(status_code, reason):
+    response = mock.Mock(spec=requests.Response)
+    response.status_code = status_code
+    # None of these values really matter, they're just accessed in Backend, so
+    # they need to exist.
+    response.url = tpuf.api_base_url
+    response.reason = reason
+    response.headers = {}
+    response.request = mock.Mock(spec=requests.PreparedRequest)
+    response.request.url = response.url
+    response.raise_for_status = lambda: requests.Response.raise_for_status(response)
+    return response
+
+
+@pytest.mark.xdist_group(name="group1")
+def test_500_retried():
+    backend = tpuf_backend.Backend("fake_api_key")
+    backend.session.send = mock.MagicMock()
+    backend.session.send.return_value = mock_response_returning(500, 'Internal Error')
+
+    with mock.patch.object(time, 'sleep', return_value=None) as sleep:
+        with pytest.raises(tpuf.error.APIError):
+            backend.make_api_request('vectors', payload={})
+        assert sleep.call_count == tpuf.max_retries - 1
+
+
+@pytest.mark.xdist_group(name="group1")
+def test_429_retried():
+    backend = tpuf_backend.Backend("fake_api_key")
+    backend.session.send = mock.MagicMock()
+    backend.session.send.return_value = mock_response_returning(429, 'Too Many Requests')
+
+    with mock.patch.object(time, 'sleep', return_value=None) as sleep:
+        with pytest.raises(tpuf.error.APIError):
+            backend.make_api_request('vectors', payload={})
+        assert sleep.call_count == tpuf.max_retries - 1

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -20,7 +20,6 @@ def mock_response_returning(status_code, reason):
     return response
 
 
-@pytest.mark.xdist_group(name="group1")
 def test_500_retried():
     backend = tpuf_backend.Backend("fake_api_key")
     backend.session.send = mock.MagicMock()
@@ -32,7 +31,6 @@ def test_500_retried():
         assert sleep.call_count == tpuf.max_retries - 1
 
 
-@pytest.mark.xdist_group(name="group1")
 def test_429_retried():
     backend = tpuf_backend.Backend("fake_api_key")
     backend.session.send = mock.MagicMock()


### PR DESCRIPTION
Which, it turns out it is, and I too misread the code and thought it wasn't.  So now there's test documentation for that behavior.