### PR TITLE
Add typing-extensions to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ iso8601 = "^2.1.0"
 orjson = { version = ">=3.9, <=3.10.3", optional = true } # 3.10.4 errors on install
 numpy = { version = ">=1.24.0", optional = true }
 pandas = { version = ">=2.0.0", optional = true }
+typing-extensions = "^4.12.2"
 
 [tool.poetry.extras]
 fast = ["orjson"]
@@ -55,7 +56,6 @@ numpy = "^1.26.3"
 
 
 [tool.poetry.group.dev.dependencies]
-typing-extensions = "^4.12.2"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
typing-extensions is added as a dev dependency, but it is imported in https://github.com/turbopuffer/turbopuffer-python/blob/main/turbopuffer/query.py – in a clean project with just `turbopuffer` added, this results in a `ModuleNotFoundError`:

```bash
$ uv init
$ uv add turbopuffer
$ uv run python3 -c "import turbopuffer; print('turbopuffer imported successfully')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import turbopuffer; print('turbopuffer imported successfully')
    ^^^^^^^^^^^^^^^^^^
  File "/Users/harryvangberg/sandbox/.venv/lib/python3.13/site-packages/turbopuffer/__init__.py", line 30, in <module>
    from turbopuffer.namespace import Namespace, namespaces, AttributeSchema, FullTextSearchParams
  File "/Users/harryvangberg/sandbox/.venv/lib/python3.13/site-packages/turbopuffer/namespace.py", line 8, in <module>
    from turbopuffer.query import VectorQuery, Filters, RankInput, ConsistencyDict
  File "/Users/harryvangberg/sandbox/.venv/lib/python3.13/site-packages/turbopuffer/query.py", line 5, in <module>
    from typing_extensions import Literal
ModuleNotFoundError: No module named 'typing_extensions'
```