### PR TITLE
do not consult response.vector_encoding_format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ optional = true
 pytest = "^7.4.3"
 flake8 = "^7.0.0"
 pytest-xdist = "^3.6.1"
+numpy = ">=1.24.0"
 
 [tool.poetry.group.compatibility]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "turbopuffer"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python Client for accessing the turbopuffer API"
 authors = ["turbopuffer Inc. <info@turbopuffer.com>"]
 homepage = "https://turbopuffer.com"

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -5,6 +5,7 @@ import tests
 import pytest
 from datetime import datetime
 from typing import List
+import numpy as np
 
 
 @pytest.mark.xdist_group(name="group1")
@@ -645,4 +646,32 @@ def test_upsert_base64_vectors():
         assert results[i-6] == tpuf.VectorRow(id=i, vector=[i/10, i/10], attributes={'test': 'rows'})
 
     ns.delete_all()
+
+def test_query_vectors_vector_encoding_format():
+    ns = tpuf.Namespace(tests.test_prefix + 'vector_encoding_format')
+    assert str(ns) == f'tpuf-namespace:{tests.test_prefix}vector_encoding_format'
+
+    ns.write(
+        upsert_rows=[
+            tpuf.VectorRow(id=1, vector=b64encode_vector([0.1, 0.2, 0.3])),
+        ],
+        distance_metric='euclidean_squared',
+    )
+
+    for vector_encoding_format in [None, 'float', 'base64']:
+        vector_set = ns.query(
+            top_k=1,
+            vector=[0.0, 0.0, 0.0],
+            distance_metric='euclidean_squared',
+            include_vectors=True,
+            vector_encoding_format=vector_encoding_format,
+        )
+        assert len(vector_set) == 1
+        assert vector_set[0].id == 1
+
+        # Compare using float32 to avoid precision issues if the vectors had
+        # been passed through 32-bit floats.
+        def float32_list(vector):
+            return [np.float32(x) for x in vector]
+        assert float32_list(vector_set[0].vector) == float32_list([0.1, 0.2, 0.3])
 

--- a/turbopuffer/namespace.py
+++ b/turbopuffer/namespace.py
@@ -282,7 +282,8 @@ class Namespace:
               include_attributes=None,
               filters=None,
               rank_by=None,
-              consistency=None) -> VectorResult:
+              consistency=None,
+              vector_encoding_format=None) -> VectorResult:
         """
         Searches vectors matching the search query.
 
@@ -298,7 +299,8 @@ class Namespace:
                 include_attributes=include_attributes,
                 filters=filters,
                 rank_by=rank_by,
-                consistency=consistency
+                consistency=consistency,
+                vector_encoding_format=vector_encoding_format,
             ))
         if not isinstance(query_data, VectorQuery):
             if isinstance(query_data, dict):

--- a/turbopuffer/vectors.py
+++ b/turbopuffer/vectors.py
@@ -70,13 +70,13 @@ class VectorRow:
 
     def from_dict(source: dict) -> 'VectorRow':
         vector = source.get('vector')
-        vector_encoding_format = source.get('vector_encoding_format')
-        if vector_encoding_format is None or vector_encoding_format == 'float':
-            pass # already in float format
-        elif vector_encoding_format == 'base64':
-            vector = b64decode_vector(vector)
-        else:
-            raise ValueError(f'Unsupported vector encoding format: {vector_encoding_format}')
+        if vector is not None:
+            if isinstance(vector, list):
+                pass # already in float format
+            elif isinstance(vector, str):
+                vector = b64decode_vector(vector)
+            else:
+                raise ValueError(f'Unsupported vector type: {type(vector)}')
         return VectorRow(
             id=source.get('id'),
             vector=vector,

--- a/turbopuffer/version.py
+++ b/turbopuffer/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.0"
+VERSION = "0.2.1"


### PR DESCRIPTION
Just look at the type of the vector field in the response.

This will need to be backported to `release-0.1` as well.