### PR TITLE
expose full response in write client call

### DIFF
--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -570,18 +570,18 @@ def test_delete_by_filter():
         distance_metric='euclidean_squared',
     )
 
-    rows_affected = ns.write(
+    res = ns.write(
         delete_by_filter=['a', 'Eq', 42] # no-op, nothing matches
     )
-    assert rows_affected == 0
+    assert res['content']['rows_affected'] == 0
 
     results = ns.vectors()
     assert len(results) == 5, "Got wrong number of vectors back"
 
-    rows_affected = ns.write(
+    res = ns.write(
         delete_by_filter=['a', 'Eq', 1]
     )
-    assert rows_affected == 2
+    assert res['content']['rows_affected'] == 2
 
     results = ns.vectors()
     assert len(results) == 3, "Got wrong number of vectors back"
@@ -589,10 +589,10 @@ def test_delete_by_filter():
     assert results[1].id == 7
     assert results[2].id == 9
 
-    rows_affected = ns.write(
+    res = ns.write(
         delete_by_filter=['a', 'Gt', 0]
     )
-    assert rows_affected == 2
+    assert res['content']['rows_affected'] == 2
 
     results = ns.vectors()
     assert len(results) == 1, "Got wrong number of vectors back"

--- a/turbopuffer/namespace.py
+++ b/turbopuffer/namespace.py
@@ -211,7 +211,7 @@ class Namespace:
           delete_by_filter: Optional[Filters] = None,
           distance_metric: Optional[Literal["cosine_distance", "euclidean_squared"]] = None,
           schema: Optional[Dict] = None,
-          encryption: Optional[EncryptionDict] = None) -> None:
+          encryption: Optional[EncryptionDict] = None) -> dict:
         """
         Create, update, or delete documents.
         """

--- a/turbopuffer/namespace.py
+++ b/turbopuffer/namespace.py
@@ -250,7 +250,7 @@ class Namespace:
         response_content = response.get('content', dict())
         assert response_content.get('status', '') == 'OK', f'Invalid write() response: {response}'
         self.metadata = None  # Invalidate cached metadata
-        return response_content.get('rows_affected')
+        return response
 
     @overload
     def query(self,


### PR DESCRIPTION
The current python client today exposes just the rows_affected integer - which seems to be from where [delete by filter was introduced](https://github.com/turbopuffer/turbopuffer-python/commit/78d931dbe300f957bc8a0ef1d332555c463659c2)

We specifically want to track `x-turbopuffer-billing-bytes-written` metric on our end to get a more granular look at where our costs are coming from, and just returning the response holistically could just help expose all the metrics the raw api provides at once