### PR TITLE
add typing_extensions as a non-dev dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 python = "^3.9"
 requests = "^2.31"
 iso8601 = "^2.1.0"
+typing-extensions = "^4.12.2"
 orjson = { version = ">=3.9", optional = true }
 numpy = { version = ">=1.24.0", optional = true }
 pandas = { version = ">=2.0.0", optional = true }
@@ -54,10 +55,6 @@ optional = true
 [tool.poetry.group.compatibility.dependencies]
 pandas = "^2.1.4"
 numpy = "^1.26.3"
-
-
-[tool.poetry.group.dev.dependencies]
-typing-extensions = "^4.12.2"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
We use this in `query.py`, so it should be a non-dev dependency.

Without this, users get a `ModuleNotFoundError` when using the library.