### PR TITLE
Fixed pip commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Usage
 
 1. Install the turbopuffer package and set your API key.
 ```sh
-$ pip install turbopuffer
+pip install turbopuffer
 ```
 Or if you're able to run C binaries for JSON encoding, use:
 ```sh
-$ pip install turbopuffer[fast]
+pip install turbopuffer[fast]
 ```
 
 2. Start using the API

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install turbopuffer
 ```
 Or if you're able to run C binaries for JSON encoding, use:
 ```sh
-pip install turbopuffer[fast]
+pip install 'turbopuffer[fast]'
 ```
 
 2. Start using the API


### PR DESCRIPTION
The copy button on the README in GitHub will copy the '$' to the clipboard, so the command won't be able to copy it into the terminal cleanly.

I also added quotes around turbopuffer[fast] as Zsh doesn't like brackets. 