### PR TITLE
Use v2 query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,21 +56,22 @@ ns.write(
 
 # Query your dataset
 results = ns.query(
-    vector=[0.18, 0.19],
+    rank_by=["vector", "ANN", [0.18, 0.19]],
     top_k=10,
     filters=['And', [
         ['name', 'Glob', '*o*'],
         ['name', 'NotEq', 'other'],
     ]],
-    include_attributes=['name'],
-    include_vectors=True
+    include_attributes=['name', 'vector'],
 )
 print(results)
 # Output:
-# [
-#   VectorRow(id=2, vector=[0.2, 0.2], attributes={'name': 'two'}, dist=0.00049999997),
-#   VectorRow(id=1, vector=[0.1, 0.1], attributes={'name': 'one'}, dist=0.0145)]
-# ]
+# QueryResult(
+#   rows=[
+#     VectorRow(id=2, vector=[0.2, 0.2], attributes={'name': 'two'}, dist=0.00049999997),
+#     VectorRow(id=1, vector=[0.1, 0.1], attributes={'name': 'one'}, dist=0.0145)
+#   ]
+# )
 
 # List all namespaces
 namespaces = tpuf.namespaces()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "turbopuffer"
-version = "0.2.4"
+version = "0.3.0"
 description = "Python Client for accessing the turbopuffer API"
 authors = ["turbopuffer Inc. <info@turbopuffer.com>"]
 homepage = "https://turbopuffer.com"

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -34,8 +34,8 @@ def test_bm25():
     )
 
     # Query with dict
-    results = ns.query({"top_k": 10, "rank_by": ("blabla", "BM25", "fox jumping")})
-    assert [item.id for item in results] == [2, 1]
+    result = ns.query({"top_k": 10, "rank_by": ("blabla", "BM25", "fox jumping")})
+    assert [item.id for item in result.rows] == [2, 1]
 
     # Upsert with named args
     ns.write(
@@ -49,7 +49,7 @@ def test_bm25():
     )
 
     # Query with named args (and combined ranking)
-    results = ns.query(
+    result = ns.query(
         top_k=2,
         rank_by=(
             "Sum",
@@ -57,7 +57,7 @@ def test_bm25():
         ),
         filters=("fact_id", "NotEq", "z"),
     )
-    assert [item.id for item in results] == [2, 4]
+    assert [item.id for item in result.rows] == [2, 4]
 
     # Upsert with row-based upsert format
     ns.write(
@@ -76,13 +76,13 @@ def test_bm25():
     )
 
     # Query to make sure the new row(s) is there
-    results = ns.query(
+    result = ns.query(
         {
             "top_k": 10,
             "rank_by": ["blabla", "BM25", "row based upsert"],
         }
     )
-    assert [item.id for item in results] == [8, 9]
+    assert [item.id for item in result.rows] == [8, 9]
 
 
 def test_bm25_product_operator():
@@ -147,11 +147,11 @@ def test_bm25_product_operator():
     ]
 
     for query in queries:
-        results = ns.query(
+        result = ns.query(
             rank_by=query,
             top_k=10,
         )
-        assert len(results) > 0
+        assert len(result.rows) > 0
 
 def test_bm25_ContainsAllTokens():
     ns = tpuf.Namespace(tests.test_prefix + "bm25_ContainsAllTokens")
@@ -178,13 +178,13 @@ def test_bm25_ContainsAllTokens():
         distance_metric="cosine_distance",
     )
 
-    results = ns.query(
+    result = ns.query(
         {
             "rank_by": ["text", "BM25", "walrus whisker"],
             "filters": ["text", "ContainsAllTokens", "marine mammals"],
         }
     )
-    assert len(results) == 1
+    assert len(result.rows) == 1
 
     missing = ns.query(
         {
@@ -192,7 +192,7 @@ def test_bm25_ContainsAllTokens():
             "filters": ["text", "ContainsAllTokens", "marine mammals short"],
         }
     )
-    assert len(missing) == 0
+    assert len(missing.rows) == 0
 
 
 def test_bm25_pre_tokenized_array():
@@ -223,18 +223,18 @@ def test_bm25_pre_tokenized_array():
         schema=schema,
     )
 
-    results = ns.query(
+    result = ns.query(
         rank_by=["content", "BM25", ["jumped"]],
         top_k=10,
     )
-    assert len(results) == 1
-    assert results[0].id == 1
+    assert len(result.rows) == 1
+    assert result.rows[0].id == 1
 
-    results = ns.query(
+    result = ns.query(
         rank_by=["content", "BM25", ["dog"]],
         top_k=10,
     )
-    assert len(results) == 2
+    assert len(result.rows) == 2
 
     with pytest.raises(tpuf.APIError, match="invalid input 'jumped' for rank_by field \"content\", expecting \\[\\]string"):
         # Query must be an array.

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -13,7 +13,8 @@ try:
             upsert_columns={
                 "id": np.arange(0, data.shape[0]),
                 "vector": data
-            }
+            },
+            distance_metric='euclidean_squared'
         )
         vecs = ns.vectors()
         for i, vec in enumerate(vecs):
@@ -23,6 +24,7 @@ try:
         # Test row upsert
         ns.write(
             upsert_rows=[{"id": i, "vector":row} for i, row in enumerate(data)],
+            distance_metric='euclidean_squared'
         )
         vecs = ns.vectors()
         for i, vec in enumerate(vecs):
@@ -34,7 +36,8 @@ try:
             upsert_columns={
                 "id": [np.int64(i) for i in range(0, data.shape[0])],
                 "vector": [[np.float64(v) for v in row] for row in data]
-            }
+            },
+            distance_metric='euclidean_squared'
         )
         vecs = ns.vectors()
         for i, vec in enumerate(vecs):

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -42,7 +42,7 @@ try:
             assert np.allclose(vec.vector, data[i])
 
         # Test query with numpy vector
-        result = ns.query(rank_by=["vector", "ANN", data[5]], distance_metric="cosine_distance", top_k=1, include_attributes=['vector'])
+        result = ns.query(rank_by=["vector", "ANN", data[5]], top_k=1, include_attributes=['vector'])
         assert len(result.rows) == 1
         assert result.rows[0].id == 5
         assert np.allclose(result.rows[0].vector, data[5])

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -42,10 +42,10 @@ try:
             assert np.allclose(vec.vector, data[i])
 
         # Test query with numpy vector
-        result = ns.query(vector=data[5], distance_metric="cosine_distance", top_k=1, include_vectors=True)
-        assert len(result) == 1
-        assert result[0].id == 5
-        assert np.allclose(result[0].vector, data[5])
+        result = ns.query(rank_by=["vector", "ANN", data[5]], distance_metric="cosine_distance", top_k=1, include_attributes=['vector'])
+        assert len(result.rows) == 1
+        assert result.rows[0].id == 5
+        assert np.allclose(result.rows[0].vector, data[5])
 
         ns.delete_all()
 

--- a/tests/test_copy_from_namespace.py
+++ b/tests/test_copy_from_namespace.py
@@ -18,5 +18,5 @@ def test_copy_from_namespace():
 
     ns2.copy_from_namespace(ns1_name)
 
-    query_results = ns2.query(vector=[0.1, 0.1], top_k=10)
-    assert len(query_results) == 4
+    query_results = ns2.query(rank_by=["vector", "ANN", [0.1, 0.1]], top_k=10)
+    assert len(query_results.rows) == 4

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -16,10 +16,10 @@ def test_order_by_attribute():
         rank_by=("fact_id", "asc"),
         top_k=10
     )
-    assert [item.id for item in results] == [1, 2, 3, 4]
+    assert [item.id for item in results.rows] == [1, 2, 3, 4]
 
     results = ns.query(
         rank_by=("fact_id", "desc"),
         top_k=10
     )
-    assert [item.id for item in results] == [4, 3, 2, 1]
+    assert [item.id for item in results.rows] == [4, 3, 2, 1]

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -31,12 +31,13 @@ def test_patches():
         ],
     )
 
-    results = ns.query(include_attributes=True)
-    assert len(results) == 2
-    assert results[0].id == 1
-    assert results[0].attributes == {'a': 1, 'b': 1}
-    assert results[1].id == 2
-    assert results[1].attributes == {'a': 2, 'b': 2}
+    result = ns.query(rank_by=["id", "asc"], include_attributes=['a', 'b'])
+    assert len(result.rows) == 2
+    print(result.rows)
+    assert result.rows[0].id == 1
+    assert result.rows[0].attributes == {'a': 1, 'b': 1}
+    assert result.rows[1].id == 2
+    assert result.rows[1].attributes == {'a': 2, 'b': 2}
 
     ns.write(
         patch_columns={
@@ -46,9 +47,9 @@ def test_patches():
         },
     )
 
-    results = ns.query(include_attributes=True)
-    assert len(results) == 2
-    assert results[0].id == 1
-    assert results[0].attributes == {'a': 11, 'b': 1, 'c': 1}
-    assert results[1].id == 2
-    assert results[1].attributes == {'a': 22, 'b': 2, 'c': 2}
+    result = ns.query(rank_by=["id", "asc"], include_attributes=['a', 'b', 'c'])
+    assert len(result.rows) == 2
+    assert result.rows[0].id == 1
+    assert result.rows[0].attributes == {'a': 11, 'b': 1, 'c': 1}
+    assert result.rows[1].id == 2
+    assert result.rows[1].attributes == {'a': 22, 'b': 2, 'c': 2}

--- a/tests/test_perf_metrics.py
+++ b/tests/test_perf_metrics.py
@@ -15,7 +15,6 @@ def test_perf_metrics():
 
     result = ns.query(
         rank_by=["vector", "ANN", [0.0, 0.3]],
-        distance_metric='cosine_distance',
         include_attributes=['hello'],
         filters=['hello', 'Eq', 'world'],
     )

--- a/tests/test_perf_metrics.py
+++ b/tests/test_perf_metrics.py
@@ -13,17 +13,17 @@ def test_perf_metrics():
         distance_metric='cosine_distance'
     )
 
-    results = ns.query(
-        vector=[0.0, 0.3],
+    result = ns.query(
+        rank_by=["vector", "ANN", [0.0, 0.3]],
         distance_metric='cosine_distance',
         include_attributes=['hello'],
         filters=['hello', 'Eq', 'world'],
     )
 
-    metrics = results.performance
+    metrics = result.performance
 
     assert type(metrics['cache_hit_ratio']) is float
     assert metrics['cache_temperature'] in ['hot', 'warm', 'cold']
     assert metrics['exhaustive_search_count'] == 2
-    assert metrics['server_time'] > 0
-    assert metrics['query_execution_time'] > 0
+    assert metrics['server_total_ms'] > 0
+    assert metrics['query_execution_ms'] > 0

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -32,21 +32,22 @@ def test_readme():
 
     # Query your dataset
     results = ns.query(
-        vector=[0.18, 0.19],
+        rank_by=["vector", "ANN", [0.18, 0.19]],
         top_k=10,
         filters=['And', [
             ['name', 'Glob', '*o*'],
             ['name', 'NotEq', 'other'],
         ]],
-        include_attributes=['name'],
-        include_vectors=True
+        include_attributes=['name', 'vector'],
     )
     print(results)
     # Output:
-    # [
-    #   VectorRow(id=2, vector=[0.2, 0.2], attributes={'name': 'two'}, dist=0.00049999997),
-    #   VectorRow(id=1, vector=[0.1, 0.1], attributes={'name': 'one'}, dist=0.0145)]
-    # ]
+    # QueryResult(
+    #   rows=[
+    #     VectorRow(id=2, vector=[0.2, 0.2], attributes={'name': 'two'}, dist=0.00049999997),
+    #     VectorRow(id=1, vector=[0.1, 0.1], attributes={'name': 'one'}, dist=0.0145)
+    #   ]
+    # )
 
     # Delete rows
     ns.write(deletes=[1, 2])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -32,7 +32,7 @@ def test_schema():
     # since it's not filterable anymore
     with pytest.raises(tpuf.TurbopufferError):
         ns.query(
-            vector=[2, 2],
+            rank_by=["vector", "ANN", [2, 2]],
             top_k=10,
             filters={
                 'hello': ['Eq', 'foobar']

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -1,5 +1,6 @@
 import uuid
 import turbopuffer as tpuf
+from turbopuffer.query import QueryBilling
 from turbopuffer.vectors import b64encode_vector
 import tests
 import pytest
@@ -218,6 +219,10 @@ def test_query_vectors():
     )
     for i in range(len(vector_set.rows)):
         check_result(vector_set.rows[i], expected[i])
+    assert vector_set.billing == QueryBilling(
+        billable_logical_bytes_queried=256000000,
+        billable_logical_bytes_returned=105,
+    )
 
     # Test query with dict
     vector_set = ns.query({

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -214,7 +214,6 @@ def test_query_vectors():
     vector_set = ns.query(
         top_k=5,
         rank_by=['vector', 'ANN', [0.8, 0.7]],
-        distance_metric='euclidean_squared',
         include_attributes=['hello', 'vector'],
     )
     for i in range(len(vector_set.rows)):
@@ -228,7 +227,6 @@ def test_query_vectors():
     vector_set = ns.query({
         'top_k': 5,
         'rank_by': ['vector', 'ANN', [0.8, 0.7]],
-        'distance_metric': 'euclidean_squared',
         'include_attributes': ['hello', 'vector'],
     })
     for i in range(len(vector_set.rows)):
@@ -238,7 +236,6 @@ def test_query_vectors():
     vector_set = ns.query(
         top_k=5,
         rank_by=['vector', 'ANN', [0.8, 0.7]],
-        distance_metric='euclidean_squared',
         include_attributes=True,
     )
     expected = [
@@ -255,7 +252,6 @@ def test_query_vectors():
     vector_set = ns.query(tpuf.VectorQuery(
         top_k=5,
         rank_by=['vector', 'ANN', [1.5, 1.6]],
-        distance_metric='euclidean_squared',
     ))
     expected = [
         tpuf.VectorRow(id=15, dist=0.01),
@@ -426,7 +422,6 @@ def test_string_ids():
     result = ns.query(
         top_k=5,
         rank_by=['vector', 'ANN', [0.0, 0.0]],
-        distance_metric='euclidean_squared',
         filters={'id': ['In', vec_ids]}
     )
     expected = [
@@ -451,7 +446,6 @@ def test_string_ids():
     result = ns.query(
         top_k=5,
         rank_by=['vector', 'ANN', [0.0, 0.0]],
-        distance_metric='euclidean_squared',
         filters={'id': ['In', vec_ids]}
     )
     expected = [
@@ -493,7 +487,6 @@ def test_attribute_types():
     result = ns.query(
         top_k=5,
         rank_by=['vector', 'ANN', [0.0, 0.0]],
-        distance_metric="euclidean_squared",
         filters={"count": [["Gt", 1]], "users": [["In", "simon"]]},
     )
     assert len(result.rows) == 1
@@ -501,7 +494,6 @@ def test_attribute_types():
     result = ns.query(
         top_k=5,
         rank_by=['vector', 'ANN', [0.0, 0.0]],
-        distance_metric="euclidean_squared",
         filters=["Or", [
             ["count", "Eq", 1],
             ["users", "Contains", "bojan"],
@@ -512,7 +504,6 @@ def test_attribute_types():
     result = ns.query(
         top_k=5,
         rank_by=['vector', 'ANN', [0.0, 0.0]],
-        distance_metric="euclidean_squared",
         filters=["And", [
             ["count", "Eq", 1],
             ["users", "Contains", "bojan"],
@@ -523,7 +514,6 @@ def test_attribute_types():
     result = ns.query(
         top_k=5,
         rank_by=['vector', 'ANN', [0.0, 0.0]],
-        distance_metric="euclidean_squared",
         filters=["And", [
             ["count", "Eq", 1],
             ["Or", [
@@ -669,7 +659,6 @@ def test_query_vectors_vector_encoding_format():
         vector_set = ns.query(
             top_k=1,
             rank_by=['vector', 'ANN', [0.0, 0.0, 0.0]],
-            distance_metric='euclidean_squared',
             include_attributes=['vector'],
             vector_encoding=vector_encoding,
         )

--- a/turbopuffer/namespace.py
+++ b/turbopuffer/namespace.py
@@ -3,7 +3,7 @@ import iso8601
 import json
 from datetime import datetime
 from turbopuffer.error import APIError
-from turbopuffer.vectors import Cursor, VectorResult, VectorColumns, VectorRow, b64decode_vector, batch_iter, b64encode_vector
+from turbopuffer.vectors import Cursor, VectorResult, VectorColumns, VectorRow, b64encode_vector
 from turbopuffer.backend import Backend
 from turbopuffer.query import VectorQuery, Filters, RankInput, ConsistencyDict, QueryResult
 from typing import Any, Dict, List, Literal, Optional, Iterable, Union, overload

--- a/turbopuffer/namespace.py
+++ b/turbopuffer/namespace.py
@@ -255,7 +255,6 @@ class Namespace:
     @overload
     def query(self,
               rank_by: RankInput,
-              distance_metric: Optional[str] = None,
               top_k: int = 10,
               include_attributes: Optional[Union[List[str], bool]] = None,
               filters: Optional[Filters] = None,
@@ -274,7 +273,6 @@ class Namespace:
     def query(self,
               query_data=None,
               rank_by=None,
-              distance_metric=None,
               top_k=None,
               include_attributes=None,
               filters=None,
@@ -288,7 +286,6 @@ class Namespace:
 
         if query_data is None:
             return self.query(VectorQuery(
-                distance_metric=distance_metric,
                 top_k=top_k,
                 include_attributes=include_attributes,
                 filters=filters,

--- a/turbopuffer/query.py
+++ b/turbopuffer/query.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 import sys
-from typing import Optional, List, Tuple, Union, Dict
-from typing import Iterable
+from typing import Any, Optional, List, Iterable, Tuple, Union, Dict
 from typing_extensions import Literal
+from turbopuffer.vectors import VectorRow
 
 # Refer to turbopuffer docs for valid operator names
 FilterOperator = str
@@ -14,6 +14,8 @@ LegacyFilterCondition = Tuple[FilterOperator, FilterValue]
 LegacyFilterDict = Dict[str, List[LegacyFilterCondition]]
 
 Filters = Union[Tuple[str, List["Filters"]], FilterCondition, LegacyFilterDict]
+
+RankInputVector = Tuple[Literal['vector'], Literal['ANN'], List[float]]
 
 RankInputTextQuery = Union[
     Tuple[str, Literal['BM25'], str],
@@ -28,6 +30,7 @@ RankInputOrderByAttribute = Tuple[str, AttributeOrdering]
 
 # Uses tuples for nice typing, but also allows arrays for backwards compatibility
 RankInput = Union[
+    RankInputVector,
     RankInputTextQuery,
     RankInputOrderByAttribute,
     List[Union[str, List[str]]],
@@ -37,50 +40,69 @@ ConsistencyDict = Dict[Literal['level'], Literal['strong', 'eventual']]
 
 @dataclass
 class VectorQuery:
-    vector: Optional[List[float]] = None
+    rank_by: RankInput
     distance_metric: Optional[str] = None
     top_k: int = 10
-    include_vectors: bool = False
     include_attributes: Optional[Union[List[str], bool]] = None
     filters: Optional[Filters] = None
-    rank_by: Optional[RankInput] = None
     consistency: Optional[ConsistencyDict] = None
-    vector_encoding_format: Optional[str] = None
+    vector_encoding: Optional[str] = None
 
     def from_dict(source: dict) -> 'VectorQuery':
         return VectorQuery(
-            vector=source.get('vector'),
             distance_metric=source.get('distance_metric'),
             top_k=source.get('top_k'),
-            include_vectors=source.get('include_vectors'),
             include_attributes=source.get('include_attributes'),
             filters=source.get('filters'),
             rank_by=source.get('rank_by'),
             consistency=source.get('consistency'),
-            vector_encoding_format=source.get('vector_encoding_format'),
+            vector_encoding=source.get('vector_encoding'),
         )
 
     def __post_init__(self):
-        if self.vector is not None:
-            if 'numpy' in sys.modules and isinstance(self.vector, sys.modules['numpy'].ndarray):
-                if self.vector.ndim != 1:
+        if self.rank_by is None:
+            raise ValueError('VectorQuery.rank_by is required')
+        if len(self.rank_by) == 3 and self.rank_by[:2] == ['vector', 'ANN']:
+            vector = self.rank_by[2]
+            if 'numpy' in sys.modules and isinstance(vector, sys.modules['numpy'].ndarray):
+                if vector.ndim != 1:
                     raise ValueError(f'VectorQuery.vector must be a 1d array, got {self.vector.ndim} dimensions')
-            elif not isinstance(self.vector, list):
-                raise ValueError('VectorQuery.vector must be a list, got:', type(self.vector))
+            elif not isinstance(vector, list):
+                raise ValueError('VectorQuery.rank_by vector must be a list, got:', type(vector))
         if self.include_attributes is not None:
             if not isinstance(self.include_attributes, list) and not isinstance(self.include_attributes, bool):
                 raise ValueError('VectorQuery.include_attributes must be a list or bool, got:', type(self.include_attributes))
         if self.filters is not None:
             if not isinstance(self.filters, dict) and not isinstance(self.filters, list) and not isinstance(self.filters, tuple):
                 raise ValueError('VectorQuery.filters must be a dict, tuple, or list, got:', type(self.filters))
-        if self.rank_by is not None:
-            if not isinstance(self.rank_by, list) and not isinstance(self.rank_by, tuple):
-                raise ValueError('VectorQuery.rank_by must be a list or tuple, got:', type(self.rank_by))
-            for item in self.rank_by:
-                if not isinstance(item, str) and not isinstance(item, list) and not isinstance(item, tuple):
-                    raise ValueError('VectorQuery.rank_by elements must be strings, tuples or lists, got:', type(item))
         if self.consistency is not None:
             if not isinstance(self.consistency, dict) or 'level' not in self.consistency:
                 raise ValueError("VectorQuery.consistency must be a dict with a 'level' key")
             if self.consistency['level'] not in ('strong', 'eventual'):
                 raise ValueError("VectorQuery.consistency level must be 'strong' or 'eventual', got:", self.consistency['level'])
+
+
+@dataclass
+class QueryBilling:
+    billable_logical_bytes_queried: int
+    billable_logical_bytes_returned: int
+
+    def from_dict(source: dict) -> 'QueryBilling':
+        return QueryBilling(
+            billable_logical_bytes_queried=source['billable_logical_bytes_queried'],
+            billable_logical_bytes_returned=source['billable_logical_bytes_returned'],
+        )
+
+
+@dataclass
+class QueryResult:
+    rows: List[VectorRow]
+    performance: Dict[str, Any]
+    billing: QueryBilling
+
+    def from_dict(source: dict) -> 'QueryResult':
+        return QueryResult(
+            rows=[VectorRow.from_dict_v2(row) for row in source['rows']],
+            performance=source['performance'],
+            billing=QueryBilling.from_dict(source['billing']),
+        )

--- a/turbopuffer/query.py
+++ b/turbopuffer/query.py
@@ -64,7 +64,7 @@ class VectorQuery:
             vector = self.rank_by[2]
             if 'numpy' in sys.modules and isinstance(vector, sys.modules['numpy'].ndarray):
                 if vector.ndim != 1:
-                    raise ValueError(f'VectorQuery.vector must be a 1d array, got {vector.ndim} dimensions')
+                    raise ValueError(f'VectorQuery.rank_by vector must be a 1d array, got {vector.ndim} dimensions')
             elif not isinstance(vector, list):
                 raise ValueError('VectorQuery.rank_by vector must be a list, got:', type(vector))
         if self.include_attributes is not None:

--- a/turbopuffer/query.py
+++ b/turbopuffer/query.py
@@ -41,7 +41,6 @@ ConsistencyDict = Dict[Literal['level'], Literal['strong', 'eventual']]
 @dataclass
 class VectorQuery:
     rank_by: RankInput
-    distance_metric: Optional[str] = None
     top_k: int = 10
     include_attributes: Optional[Union[List[str], bool]] = None
     filters: Optional[Filters] = None
@@ -50,7 +49,6 @@ class VectorQuery:
 
     def from_dict(source: dict) -> 'VectorQuery':
         return VectorQuery(
-            distance_metric=source.get('distance_metric'),
             top_k=source.get('top_k'),
             include_attributes=source.get('include_attributes'),
             filters=source.get('filters'),
@@ -66,7 +64,7 @@ class VectorQuery:
             vector = self.rank_by[2]
             if 'numpy' in sys.modules and isinstance(vector, sys.modules['numpy'].ndarray):
                 if vector.ndim != 1:
-                    raise ValueError(f'VectorQuery.vector must be a 1d array, got {self.vector.ndim} dimensions')
+                    raise ValueError(f'VectorQuery.vector must be a 1d array, got {vector.ndim} dimensions')
             elif not isinstance(vector, list):
                 raise ValueError('VectorQuery.rank_by vector must be a list, got:', type(vector))
         if self.include_attributes is not None:

--- a/turbopuffer/vectors.py
+++ b/turbopuffer/vectors.py
@@ -84,6 +84,14 @@ class VectorRow:
             dist=source.get('dist'),
         )
 
+    def from_dict_v2(source: dict) -> 'VectorRow':
+        id = source.pop('id')
+        vector = source.pop('vector', None)
+        dist = source.pop('$dist', None)
+        if len(source) == 0:
+            source = None
+        return VectorRow.from_dict({'id': id, 'vector': vector, 'attributes': source, 'dist': dist})
+
     def __post_init__(self):
         if not isinstance(self.id, int) and not isinstance(self.id, str):
             raise ValueError('VectorRow.id must be an int or str, got:', type(self.id))

--- a/turbopuffer/version.py
+++ b/turbopuffer/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.4"
+VERSION = "0.3.0"


### PR DESCRIPTION
This is a SemVer-breaking change, as it introduces the following non-backwards compatible changes:

  * The response type of `.query` changes from `list[VectorRow]` to a `QueryResult` type, which has a `rows: list[VectorRow]` attribute.

  * `VectorsQuery.rank_by` is now a required parameter.

  * `VectorsQuery.vector` is removed, and replaced by `rank_by=["vector", "ANN", ...]`.

  * `include_vectors=True` is replaced by `include_attributes=["vector", ...]`.

  * Specifying `include_attributes=True` now includes the `vector` attribute.

  * `VectorsQuery.distance_metric` is removed with no replacement. (Specifying a distance metric on upserts is about to be required.)

One notable callout: `VectorRow` does *not* flatten attributes the way that the v2 query API does. `id`, `vector`, and `dist` are still special attributes that have dedicated handling. Adjusting this is quite difficult, given the special handling that the `vector` type gets, and doesn't seem worth the trouble given that we'll be switching to Stainless soon.