### PR TITLE
[TPUF-358] Mandate `top_k` in `query`

### DIFF
--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -182,6 +182,7 @@ def test_bm25_ContainsAllTokens():
         {
             "rank_by": ["text", "BM25", "walrus whisker"],
             "filters": ["text", "ContainsAllTokens", "marine mammals"],
+            "top_k": 10,
         }
     )
     assert len(result.rows) == 1
@@ -190,6 +191,7 @@ def test_bm25_ContainsAllTokens():
         {
             "rank_by": ["text", "BM25", "walrus whisker"],
             "filters": ["text", "ContainsAllTokens", "marine mammals short"],
+            "top_k": 10,
         }
     )
     assert len(missing.rows) == 0

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -31,7 +31,7 @@ def test_patches():
         ],
     )
 
-    result = ns.query(rank_by=["id", "asc"], include_attributes=['a', 'b'])
+    result = ns.query(rank_by=["id", "asc"], include_attributes=['a', 'b'], top_k=10)
     assert len(result.rows) == 2
     print(result.rows)
     assert result.rows[0].id == 1
@@ -47,7 +47,7 @@ def test_patches():
         },
     )
 
-    result = ns.query(rank_by=["id", "asc"], include_attributes=['a', 'b', 'c'])
+    result = ns.query(rank_by=["id", "asc"], include_attributes=['a', 'b', 'c'], top_k=10)
     assert len(result.rows) == 2
     assert result.rows[0].id == 1
     assert result.rows[0].attributes == {'a': 11, 'b': 1, 'c': 1}

--- a/tests/test_perf_metrics.py
+++ b/tests/test_perf_metrics.py
@@ -17,6 +17,7 @@ def test_perf_metrics():
         rank_by=["vector", "ANN", [0.0, 0.3]],
         include_attributes=['hello'],
         filters=['hello', 'Eq', 'world'],
+        top_k=10,
     )
 
     metrics = result.performance

--- a/turbopuffer/query.py
+++ b/turbopuffer/query.py
@@ -41,7 +41,7 @@ ConsistencyDict = Dict[Literal['level'], Literal['strong', 'eventual']]
 @dataclass
 class VectorQuery:
     rank_by: RankInput
-    top_k: int = 10
+    top_k: int
     include_attributes: Optional[Union[List[str], bool]] = None
     filters: Optional[Filters] = None
     consistency: Optional[ConsistencyDict] = None
@@ -67,6 +67,8 @@ class VectorQuery:
                     raise ValueError(f'VectorQuery.rank_by vector must be a 1d array, got {vector.ndim} dimensions')
             elif not isinstance(vector, list):
                 raise ValueError('VectorQuery.rank_by vector must be a list, got:', type(vector))
+        if self.top_k is None:
+            raise ValueError('VectorQuery.top_k is required')
         if self.include_attributes is not None:
             if not isinstance(self.include_attributes, list) and not isinstance(self.include_attributes, bool):
                 raise ValueError('VectorQuery.include_attributes must be a list or bool, got:', type(self.include_attributes))


### PR DESCRIPTION
To align with a forthcoming change to the backend API. The goal is to limit a longstanding confusion where users issue a query and don't realize there's a default top_k of 10. (Most databases default to an unlimited result set size.)