### PR TITLE
handle case when base_url doesnt have protocol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "turbopuffer"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python Client for accessing the turbopuffer API"
 authors = ["turbopuffer Inc. <info@turbopuffer.com>"]
 homepage = "https://turbopuffer.com"

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -57,6 +57,10 @@ except ImportError:
     print('Skipped numpy tests')
 
 def test_base_url_compatibility():
+    assert tpuf.backend.clean_base_url("domain") == "https://domain"
+    assert tpuf.backend.clean_base_url("https://domain") == "https://domain"
+    assert tpuf.backend.clean_base_url("http://domain") == "http://domain"
+    assert tpuf.backend.clean_base_url("admin://domain") == "admin://domain"
     assert tpuf.backend.clean_base_url("https://domain/v1/") == "https://domain"
     assert tpuf.backend.clean_base_url("https://domain/v1") == "https://domain"
     assert tpuf.backend.clean_base_url("https://domain/") == "https://domain"

--- a/turbopuffer/backend.py
+++ b/turbopuffer/backend.py
@@ -20,10 +20,15 @@ def find_api_key(api_key: Optional[str] = None) -> str:
                                   "or pass `api_key=` when creating a Namespace.")
 
 def clean_base_url(base_url: str) -> str:
-    if base_url.endswith(('/v1', '/v1/', '/')):
-        return re.sub('(/v1|/v1/|/)$', '', base_url)
-    else:
-        return base_url
+    url = base_url.strip()
+
+    if '://' not in url:
+        url = f'https://{url}'
+
+    if url.endswith(('/v1', '/v1/', '/')):
+        url = re.sub('(/v1|/v1/|/)$', '', url)
+
+    return url
 
 
 class Backend:

--- a/turbopuffer/version.py
+++ b/turbopuffer/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.4.0"
+VERSION = "0.4.1"


### PR DESCRIPTION
for better DX, allow users to use a base_url without the protocol (this is what browsers implicitly do too for eg.). One scenario where this can happen is if you copy a region from the site regions page

mirrors the TS client: https://github.com/turbopuffer/turbopuffer-typescript/pull/79