### PR TITLE
tests: add distance metric to inaugural writes

### DIFF
--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -30,6 +30,7 @@ def test_bm25():
             ],
             "fact_id": ["a", "b", "c", "d"],
         },
+        distance_metric='euclidean_squared',
         schema=schema,
     )
 
@@ -117,6 +118,7 @@ def test_bm25_product_operator():
             "title": "the lazy dog",
             "content": "is brown",
         }],
+        distance_metric='euclidean_squared',
         schema=schema,
     )
 

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -9,7 +9,8 @@ def test_order_by_attribute():
             "id": [1, 2, 3, 4],
             "vector": [[0.1, 0.1], [0.2, 0.2], [0.3, 0.3], [0.4, 0.4]],
             "fact_id": ["a", "b", "c", "d"],
-        }
+        },
+        distance_metric='euclidean_squared',
     )
 
     results = ns.query(

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -376,7 +376,8 @@ def test_string_ids():
             "key1": key1,
             "key2": key2,
             "test": ["cols", "cols", "cols", "cols"],
-        }
+        },
+        distance_metric='euclidean_squared',
     )
 
     # Test upsert rows


### PR DESCRIPTION
We'll rewrite this in write V2 shortly, need this to pass tests.