### PR TITLE
feat: improve performance with custom transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ The REST API documentation can be found on [turbopuffer.com](https://turbopuffer
 pip install --pre turbopuffer
 ```
 
+Or, if you're able to run C binaries for JSON encoding:
+
+```sh
+pip install --pre turbopuffer[fast]
+```
+
 ## Usage
 
 ```python

--- a/README.md
+++ b/README.md
@@ -2,24 +2,20 @@
 
 <a href="https://pypi.org/project/turbopuffer/"><img src="https://img.shields.io/pypi/v/turbopuffer.svg" alt="PyPI version" align="right"></a>
 
-The Turbopuffer Python library provides convenient access to the Turbopuffer REST API from any Python 3.8+
+The Turbopuffer Python library provides convenient access to the Turbopuffer HTTP API from any Python 3.8+
 application. The library includes type definitions for all request params and response fields,
 and offers both synchronous and asynchronous clients powered by [httpx](https://github.com/encode/httpx).
 
 It is generated with [Stainless](https://www.stainless.com/).
 
-
-> [!WARNING]
-> **This version of the turbopuffer Python client is in alpha.**
+> [!IMPORTANT]
+> **The latest version of the Python SDK (v0.5) contains several breaking changes.**
 >
-> You may encounter bugs or performance issues. APIs are subject to change.
->
-> The stable version of the turbopuffer Python client is [v0.4.1](https://pypi.org/project/turbopuffer/0.4.1/).
-
+> Consult [UPGRADING.md](./UPGRADING.md) for details.
 
 ## Documentation
 
-The REST API documentation can be found on [turbopuffer.com](https://turbopuffer.com/docs).
+The HTTP API documentation can be found on [turbopuffer.com](https://turbopuffer.com/docs).
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ authors = [
 ]
 dependencies = [
     "httpx>=0.23.0, <1",
+    "aiohttp>=3.12.11, <4",
+    "urllib3>=2.4.0, <3",
     "pydantic>=1.9.0, <3",
     "pybase64>=1.4.1, <2",
     "typing-extensions>=4.13, <5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ classifiers = [
   "License :: OSI Approved :: MIT License"
 ]
 
+[project.optional-dependencies]
+fast = ["orjson>=3.10.18, <4"]
+
 [project.urls]
 Homepage = "https://github.com/turbopuffer/turbopuffer-python"
 Repository = "https://github.com/turbopuffer/turbopuffer-python"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -76,6 +76,8 @@ nodeenv==1.8.0
     # via pyright
 nox==2023.4.22
 numpy==2.0.2
+orjson==3.10.18
+    # via turbopuffer
 packaging==23.2
     # via nox
     # via pytest

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,6 +10,12 @@
 #   universal: false
 
 -e file:.
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.12.11
+    # via turbopuffer
+aiosignal==1.3.2
+    # via aiohttp
 annotated-types==0.6.0
     # via pydantic
 anyio==4.4.0
@@ -17,6 +23,10 @@ anyio==4.4.0
     # via turbopuffer
 argcomplete==3.1.2
     # via nox
+async-timeout==5.0.1
+    # via aiohttp
+attrs==25.3.0
+    # via aiohttp
 certifi==2023.7.22
     # via httpcore
     # via httpx
@@ -34,6 +44,9 @@ execnet==2.1.1
     # via pytest-xdist
 filelock==3.12.4
     # via virtualenv
+frozenlist==1.6.2
+    # via aiohttp
+    # via aiosignal
 h11==0.14.0
     # via httpcore
 httpcore==1.0.2
@@ -44,6 +57,7 @@ httpx==0.28.1
 idna==3.4
     # via anyio
     # via httpx
+    # via yarl
 importlib-metadata==7.0.0
 iniconfig==2.0.0
     # via pytest
@@ -51,6 +65,9 @@ markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
+multidict==6.4.4
+    # via aiohttp
+    # via yarl
 mypy==1.14.1
 mypy-extensions==1.0.0
     # via mypy
@@ -66,6 +83,9 @@ platformdirs==3.11.0
     # via virtualenv
 pluggy==1.5.0
     # via pytest
+propcache==0.3.1
+    # via aiohttp
+    # via yarl
 pybase64==1.4.1
     # via turbopuffer
 pydantic==2.10.3
@@ -100,12 +120,17 @@ tomli==2.0.2
     # via pytest
 typing-extensions==4.13.2
     # via anyio
+    # via multidict
     # via mypy
     # via pydantic
     # via pydantic-core
     # via pyright
     # via turbopuffer
+urllib3==2.4.0
+    # via turbopuffer
 virtualenv==20.24.5
     # via nox
+yarl==1.20.0
+    # via aiohttp
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements.lock
+++ b/requirements.lock
@@ -10,11 +10,21 @@
 #   universal: false
 
 -e file:.
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.12.11
+    # via turbopuffer
+aiosignal==1.3.2
+    # via aiohttp
 annotated-types==0.6.0
     # via pydantic
 anyio==4.4.0
     # via httpx
     # via turbopuffer
+async-timeout==5.0.1
+    # via aiohttp
+attrs==25.3.0
+    # via aiohttp
 certifi==2023.7.22
     # via httpcore
     # via httpx
@@ -22,6 +32,9 @@ distro==1.8.0
     # via turbopuffer
 exceptiongroup==1.2.2
     # via anyio
+frozenlist==1.6.2
+    # via aiohttp
+    # via aiosignal
 h11==0.14.0
     # via httpcore
 httpcore==1.0.2
@@ -31,6 +44,13 @@ httpx==0.28.1
 idna==3.4
     # via anyio
     # via httpx
+    # via yarl
+multidict==6.4.4
+    # via aiohttp
+    # via yarl
+propcache==0.3.1
+    # via aiohttp
+    # via yarl
 pybase64==1.4.1
     # via turbopuffer
 pydantic==2.10.3
@@ -42,6 +62,11 @@ sniffio==1.3.0
     # via turbopuffer
 typing-extensions==4.13.2
     # via anyio
+    # via multidict
     # via pydantic
     # via pydantic-core
     # via turbopuffer
+urllib3==2.4.0
+    # via turbopuffer
+yarl==1.20.0
+    # via aiohttp

--- a/requirements.lock
+++ b/requirements.lock
@@ -48,6 +48,8 @@ idna==3.4
 multidict==6.4.4
     # via aiohttp
     # via yarl
+orjson==3.10.18
+    # via turbopuffer
 propcache==0.3.1
     # via aiohttp
     # via yarl

--- a/src/turbopuffer/_response.py
+++ b/src/turbopuffer/_response.py
@@ -25,6 +25,7 @@ import anyio
 import httpx
 import pydantic
 
+from .lib import json
 from ._types import NoneType
 from ._utils import is_given, extract_type_arg, is_annotated_type, is_type_alias_type, extract_type_var_from_base
 from ._models import BaseModel, is_basemodel
@@ -240,7 +241,7 @@ class BaseAPIResponse(Generic[R]):
         if not content_type.endswith("json"):
             if is_basemodel(cast_to):
                 try:
-                    data = response.json()
+                    data = json.loads(response.content)
                 except Exception as exc:
                     log.debug("Could not read JSON from response data due to %s - %s", type(exc), exc)
                 else:
@@ -262,7 +263,7 @@ class BaseAPIResponse(Generic[R]):
             # handle the response however you need to.
             return response.text  # type: ignore
 
-        data = response.json()
+        data = json.loads(response.content)
 
         return self._client._process_response_data(
             data=data,

--- a/src/turbopuffer/_streaming.py
+++ b/src/turbopuffer/_streaming.py
@@ -1,7 +1,6 @@
 # Note: initially copied from https://github.com/florimondmanca/httpx-sse/blob/master/src/httpx_sse/_decoders.py
 from __future__ import annotations
 
-import json
 import inspect
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, Iterator, AsyncIterator, cast
@@ -9,6 +8,7 @@ from typing_extensions import Self, Protocol, TypeGuard, override, get_origin, r
 
 import httpx
 
+from .lib import json
 from ._utils import extract_type_var_from_base
 
 if TYPE_CHECKING:

--- a/src/turbopuffer/lib/json.py
+++ b/src/turbopuffer/lib/json.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+try:
+    import orjson
+
+    loads = orjson.loads
+
+    def dumps(obj: Any) -> bytes:
+        return orjson.dumps(obj)
+
+except ImportError:
+    import json
+
+    loads = json.loads
+
+    def dumps(obj: Any) -> bytes:
+        return json.dumps(obj).encode()

--- a/src/turbopuffer/lib/namespace.py
+++ b/src/turbopuffer/lib/namespace.py
@@ -50,7 +50,6 @@ class Namespace(namespaces.NamespacesResource, NamespaceMixin):
         )
 
 
-
 class NamespaceWithRawResponse(namespaces.NamespacesResourceWithRawResponse, NamespaceMixin):
     def __init__(self, client: Turbopuffer) -> None:
         super().__init__(namespaces.NamespacesResource(client))

--- a/src/turbopuffer/lib/performance.py
+++ b/src/turbopuffer/lib/performance.py
@@ -1,0 +1,59 @@
+import time
+from typing import Any, Dict, Optional
+
+from .._models import BaseModel
+
+
+class ClientPerformance(BaseModel):
+    client_total_ms: float
+    """Total request time in milliseconds, measured on the client.
+
+    Note this only includes the time spent during the last retry.
+    """
+
+    client_compress_ms: float
+    """Number of milliseconds spent compressing the request on the client."""
+
+    client_response_ms: Optional[float]
+    """Number of milliseconds between the start of the request and receiving the
+    last response header from the server.
+    """
+
+    client_body_read_ms: Optional[float]
+    """Number of milliseconds between receiving the last response header from
+    the server and receiving the end of the response body from the server.
+    """
+
+    client_deserialize_ms: float
+    """Number of milliseconds spent deserializing the response on the client."""
+
+
+def merge_clock_into_response(response: Any, clock: Dict[str, float]) -> None:
+    # HACK: we assume any response with a `performance` property of type
+    # `ClientPerformance` wants client performance metrics merged into that
+    # object.
+    performance = getattr(response, "performance", None)
+    if isinstance(performance, ClientPerformance):
+        end = time.monotonic()
+
+        # These always exist, regardless of transport.
+        request_start: float = clock["request_start"]
+        deserialize_start: float = clock["deserialize_start"]
+
+        # These exist only when using our default (custom) transports.
+        compress_start: Optional[float] = clock.get("compress_start")
+        compress_end: Optional[float] = clock.get("compress_end")
+        response_headers_end: Optional[float] = clock.get("response_headers_end")
+        body_read_end: Optional[float] = clock.get("body_read_end")
+
+        performance.client_total_ms = (end - request_start) * 1000
+        performance.client_deserialize_ms = (end - deserialize_start) * 1000
+
+        if compress_start and compress_end:
+            performance.client_compress_ms = (compress_end - compress_start) * 1000
+
+        if response_headers_end:
+            performance.client_response_ms = (response_headers_end - request_start) * 1000
+
+        if body_read_end and response_headers_end:
+            performance.client_body_read_ms = (body_read_end - response_headers_end) * 1000

--- a/src/turbopuffer/lib/transport.py
+++ b/src/turbopuffer/lib/transport.py
@@ -1,0 +1,1 @@
+MIN_GZIP_SIZE = 1024

--- a/src/turbopuffer/lib/transport_aiohttp.py
+++ b/src/turbopuffer/lib/transport_aiohttp.py
@@ -1,0 +1,136 @@
+# Copyright © 2025, Karen Petrosyan. All rights reserved.
+# Obtained from the following URL on 9 June 2025:
+# https://github.com/karpetrosyan/httpx-aiohttp/tree/6bfcb1dcf13632aa5338e49b13dccf54bd51ca65
+#
+# The default async transport for `httpx` is quite slow, so we use this
+# aiohttp-based transport instead.
+
+import gzip
+import time
+import typing
+import asyncio
+import contextlib
+from typing_extensions import override
+
+import httpx
+import aiohttp
+from aiohttp import ClientTimeout
+from aiohttp.client import ClientSession, ClientResponse
+
+from .transport import MIN_GZIP_SIZE
+
+AIOHTTP_EXC_MAP = {
+    aiohttp.ServerTimeoutError: httpx.TimeoutException,
+    aiohttp.ConnectionTimeoutError: httpx.ConnectTimeout,
+    aiohttp.SocketTimeoutError: httpx.ReadTimeout,
+    aiohttp.ClientConnectorError: httpx.ConnectError,
+    aiohttp.ClientPayloadError: httpx.ReadError,
+    aiohttp.ClientProxyConnectionError: httpx.ProxyError,
+}
+
+
+@contextlib.contextmanager
+def map_aiohttp_exceptions() -> typing.Iterator[None]:
+    try:
+        yield
+    except Exception as exc:
+        mapped_exc = None
+
+        for from_exc, to_exc in AIOHTTP_EXC_MAP.items():
+            if not isinstance(exc, from_exc):  # type: ignore
+                continue
+            if mapped_exc is None or issubclass(to_exc, mapped_exc):  # type: ignore
+                mapped_exc = to_exc
+
+        if mapped_exc is None:  # pragma: no cover
+            raise
+
+        message = str(exc)
+        raise mapped_exc(message) from exc
+
+
+class AiohttpResponseStream(httpx.AsyncByteStream):
+    CHUNK_SIZE = 1024 * 16
+
+    def __init__(self, aiohttp_response: ClientResponse) -> None:
+        self._aiohttp_response = aiohttp_response
+
+    @override
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        with map_aiohttp_exceptions():
+            async for chunk in self._aiohttp_response.content.iter_chunked(self.CHUNK_SIZE):
+                yield chunk
+
+    @override
+    async def aclose(self) -> None:
+        with map_aiohttp_exceptions():
+            await self._aiohttp_response.__aexit__(None, None, None)
+
+
+class AiohttpTransport(httpx.AsyncBaseTransport):
+    def __init__(self, client: typing.Union[ClientSession, typing.Callable[[], ClientSession]]) -> None:
+        self.client = client
+
+    @override
+    async def handle_async_request(
+        self,
+        request: httpx.Request,
+    ) -> httpx.Response:
+        clock = request.extensions["clock"]
+        timeout = request.extensions.get("timeout", {})
+        sni_hostname = request.extensions.get("sni_hostname")
+
+        if not isinstance(self.client, ClientSession):
+            self.client = self.client()
+
+        # Compress the request content if worthwhile.
+        content = request.content
+        clock["compress_start"] = time.monotonic()
+        clock["compress_end"] = clock["compress_start"]  # overwritten later if we actually compress
+        if len(request.content) > MIN_GZIP_SIZE:
+            loop = asyncio.get_event_loop()
+            content = await loop.run_in_executor(None, lambda: gzip.compress(content, compresslevel=1))
+            request.headers["Content-Encoding"] = "gzip"
+            request.headers["Content-Length"] = str(len(content))
+            clock["compress_end"] = time.monotonic()
+
+        with map_aiohttp_exceptions():
+            response = await self.client.request(
+                method=request.method,
+                url=str(request.url),
+                headers=request.headers,
+                data=content,
+                allow_redirects=False,
+                auto_decompress=False,
+                compress=False,
+                timeout=ClientTimeout(
+                    sock_connect=timeout.get("connect"),
+                    sock_read=timeout.get("read"),
+                    connect=timeout.get("pool"),
+                ),
+                server_hostname=sni_hostname,
+            ).__aenter__()
+            clock["response_headers_end"] = time.monotonic()
+
+        httpx_response = httpx.Response(
+            status_code=response.status,
+            headers=response.headers,
+            content=AiohttpResponseStream(response),
+            request=request,
+            extensions={
+                # Smuggle the clock through the response object.
+                "clock": clock,
+            },
+        )
+
+        # Eagerly read the response content (which will be cached on the
+        # response object) so that we can time the body read.
+        await httpx_response.aread()
+        clock["body_read_end"] = time.monotonic()
+
+        return httpx_response
+
+    @override
+    async def aclose(self) -> None:
+        if isinstance(self.client, ClientSession):
+            await self.client.close()

--- a/src/turbopuffer/lib/transport_httpx.py
+++ b/src/turbopuffer/lib/transport_httpx.py
@@ -1,0 +1,36 @@
+import gzip
+import time
+from typing_extensions import override
+
+import httpx
+
+from .transport import MIN_GZIP_SIZE
+
+
+class HttpxTransport(httpx.HTTPTransport):
+    @override
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        clock = request.extensions["clock"]
+
+        # Compress the request content if worthwhile.
+        clock["compress_start"] = time.monotonic()
+        clock["compress_end"] = clock["compress_start"]  # overwritten later if we actually compress
+        if len(request.content) > MIN_GZIP_SIZE:
+            request._content = gzip.compress(request.content, compresslevel=1)
+            request.stream = httpx.ByteStream(request._content)
+            request.headers["Content-Encoding"] = "gzip"
+            request.headers["Content-Length"] = str(len(request.content))
+            clock["compress_end"] = time.monotonic()
+
+        response = super().handle_request(request)
+        clock["response_headers_end"] = time.monotonic()
+
+        # Eagerly read the response content (which will be cached on the
+        # response object) so that we can time the body read.
+        response.read()
+        clock["body_read_end"] = time.monotonic()
+
+        # Smuggle the clock through the response object.
+        response.extensions["clock"] = clock
+
+        return response

--- a/src/turbopuffer/lib/transport_urllib3.py
+++ b/src/turbopuffer/lib/transport_urllib3.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2020 Florimond Manca
+# Obtained from the following URL on 9 June 2025:
+# https://gist.github.com/florimondmanca/d56764d78d748eb9f73165da388e546e
+#
+# In theory this should be faster than the default `httpx` transport, but in
+# practice it seems to be slightly slower. We keep it here in case it's useful
+# in the future.
+
+import ssl
+import gzip
+import time
+import typing
+from typing_extensions import override
+
+import httpx
+import urllib3
+from httpx._types import CertTypes, ProxyTypes, SyncByteStream
+from httpx._config import create_ssl_context
+
+from .transport import MIN_GZIP_SIZE
+
+
+def httpx_headers_to_urllib3_headers(headers: httpx.Headers) -> urllib3.HTTPHeaderDict:
+    urllib3_headers = urllib3.HTTPHeaderDict()
+    for name, value in headers.multi_items():
+        urllib3_headers.add(name, value)
+    return urllib3_headers
+
+
+class ResponseStream(SyncByteStream):
+    CHUNK_SIZE = 1024
+
+    def __init__(self, urllib3_stream: typing.Any) -> None:
+        self._urllib3_stream = urllib3_stream
+
+    @override
+    def __iter__(self) -> typing.Iterator[bytes]:
+        for chunk in self._urllib3_stream.stream(self.CHUNK_SIZE, decode_content=False):
+            yield chunk
+
+    @override
+    def close(self) -> None:
+        self._urllib3_stream.release_conn()
+
+
+class Urllib3Transport(httpx.BaseTransport):
+    def __init__(
+        self,
+        verify: typing.Union[ssl.SSLContext, str, bool] = True,
+        trust_env: bool = True,
+        max_pools: int = 10,
+        maxsize: int = 10,
+        cert: typing.Union[CertTypes, None] = None,
+        proxy: typing.Union[ProxyTypes, None] = None,
+    ) -> None:
+        ssl_context = create_ssl_context(cert=cert, verify=verify, trust_env=trust_env)
+        proxy = httpx.Proxy(url=proxy) if isinstance(proxy, (str, httpx.URL)) else proxy
+
+        if proxy is None:
+            self._pool = urllib3.PoolManager(
+                ssl_context=ssl_context,
+                num_pools=max_pools,
+                maxsize=maxsize,
+                block=False,
+            )
+        elif proxy.url.scheme in ("http", "https"):
+            self._pool = urllib3.ProxyManager(
+                str(proxy.url.netloc),
+                num_pools=max_pools,
+                maxsize=maxsize,
+                block=False,
+                proxy_ssl_context=proxy.ssl_context,
+                proxy_headers=httpx_headers_to_urllib3_headers(proxy.headers),
+                ssl_context=ssl_context,
+            )
+        elif proxy.url.scheme == "socks5":
+            from urllib3.contrib.socks import SOCKSProxyManager
+
+            username, password = proxy.auth or (None, None)
+
+            self._pool = SOCKSProxyManager(
+                proxy_url=str(proxy.url),
+                num_pools=max_pools,
+                maxsize=maxsize,
+                block=False,
+                username=username,
+                password=password,
+            )
+        else:
+            raise ValueError(
+                f"Proxy protocol must be either 'http', 'https', or 'socks5', but got {proxy.url.scheme!r}."
+            )
+
+    @override
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        clock = request.extensions["clock"]
+        timeouts = request.extensions.get("timeout", {})
+
+        connect_timeout = timeouts.get("connect", None)
+        read_timeout = timeouts.get("read", None)
+
+        urllib3_timeout = urllib3.Timeout(
+            connect=connect_timeout,
+            read=read_timeout,
+        )
+
+        # Compress the request content if worthwhile.
+        content = request.content
+        clock["compress_start"] = time.monotonic()
+        clock["compress_end"] = clock["compress_start"]  # overwritten later if we actually compress
+        if len(request.content) > MIN_GZIP_SIZE:
+            content = gzip.compress(request.content, compresslevel=1)
+            request.headers["Content-Encoding"] = "gzip"
+            request.headers["Content-Length"] = str(len(content))
+            clock["compress_end"] = time.monotonic()
+
+        response = self._pool.request(
+            request.method,
+            str(request.url),
+            body=content,
+            headers=httpx_headers_to_urllib3_headers(request.headers),
+            redirect=False,
+            preload_content=False,
+            timeout=urllib3_timeout,
+        )
+        clock["response_headers_end"] = time.monotonic()
+
+        httpx_response = httpx.Response(
+            status_code=response.status,
+            headers=httpx.Headers([(name, value) for name, value in response.headers.iteritems()]),
+            content=ResponseStream(response),
+            extensions={
+                # Smuggle the clock through the response object.
+                "clock": clock,
+            },
+        )
+
+        # Eagerly read the response content (which will be cached on the
+        # response object) so that we can time the body read.
+        httpx_response.read()
+        clock["body_read_end"] = time.monotonic()
+
+        return httpx_response

--- a/src/turbopuffer/types/query_performance.py
+++ b/src/turbopuffer/types/query_performance.py
@@ -1,11 +1,11 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from .._models import BaseModel
+from ..lib.performance import ClientPerformance
 
 __all__ = ["QueryPerformance"]
 
 
-class QueryPerformance(BaseModel):
+class QueryPerformance(ClientPerformance):
     approx_namespace_size: int
     """the approximate number of documents in the namespace."""
 

--- a/tests/custom/conftest.py
+++ b/tests/custom/conftest.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from typing import Iterator, AsyncIterator
 
 import pytest
 
@@ -12,5 +12,5 @@ def tpuf() -> Iterator[Turbopuffer]:
 
 
 @pytest.fixture(scope="session")
-def async_tpuf() -> Iterator[AsyncTurbopuffer]:
+async def async_tpuf() -> AsyncIterator[AsyncTurbopuffer]:
     yield AsyncTurbopuffer()

--- a/tests/custom/test_async.py
+++ b/tests/custom/test_async.py
@@ -1,10 +1,7 @@
-import pytest
-
 from turbopuffer import AsyncTurbopuffer
 from tests.custom import test_prefix
 
 
-@pytest.mark.asyncio
 async def test_order_by_attribute(async_tpuf: AsyncTurbopuffer):
     ns = async_tpuf.namespace(test_prefix + "order_by_attribute")
 
@@ -26,7 +23,6 @@ async def test_order_by_attribute(async_tpuf: AsyncTurbopuffer):
     assert [item.id for item in results.rows] == [4, 3, 2, 1]
 
 
-@pytest.mark.asyncio
 async def test_exists(async_tpuf: AsyncTurbopuffer):
     ns = async_tpuf.namespace(test_prefix + "exists-test-async")
     assert (await ns.exists()) is False

--- a/tests/custom/test_compression.py
+++ b/tests/custom/test_compression.py
@@ -1,0 +1,142 @@
+import pytest
+
+import turbopuffer
+from turbopuffer import Turbopuffer, AsyncTurbopuffer
+from tests.custom import test_prefix
+
+
+def test_compression_auto_on(tpuf: Turbopuffer):
+    ns = tpuf.namespace(test_prefix + "compression-auto-on")
+
+    try:
+        ns.delete_all()
+    except turbopuffer.NotFoundError:
+        pass
+
+    ns.write(
+        upsert_rows=[
+            {
+                "id": 1,
+                "vector": [0.1] * 1024,
+                "title": "test doc",
+            },
+        ],
+        distance_metric="euclidean_squared",
+    )
+
+    # This request is large enough to be compressed.
+    result = ns.query(
+        rank_by=("vector", "ANN", [0.1] * 1024),
+        top_k=1,
+        include_attributes=True,
+    )
+
+    perf = result.performance
+    assert perf.client_total_ms > 0
+    assert perf.client_compress_ms > 0
+    assert perf.client_response_ms is not None and perf.client_response_ms > 0
+    assert perf.client_body_read_ms is not None and perf.client_body_read_ms > 0
+    assert perf.client_deserialize_ms > 0
+
+
+def test_compression_auto_off(tpuf: Turbopuffer):
+    ns = tpuf.namespace(test_prefix + "compression-auto-off")
+
+    try:
+        ns.delete_all()
+    except turbopuffer.NotFoundError:
+        pass
+
+    ns.write(
+        upsert_rows=[
+            {
+                "id": 1,
+                "vector": [0.1],
+                "title": "test doc",
+            },
+        ],
+        distance_metric="euclidean_squared",
+    )
+
+    # This request is too small to be compressed.
+    result = ns.query(
+        rank_by=("vector", "ANN", [0.1]),
+        top_k=1,
+        include_attributes=True,
+    )
+
+    perf = result.performance
+    assert perf.client_total_ms > 0
+    assert perf.client_compress_ms == 0
+    assert perf.client_response_ms is not None and perf.client_response_ms > 0
+    assert perf.client_body_read_ms is not None and perf.client_body_read_ms > 0
+    assert perf.client_deserialize_ms > 0
+
+
+@pytest.mark.asyncio
+async def test_async_compression_auto_on(async_tpuf: AsyncTurbopuffer):
+    ns = async_tpuf.namespace(test_prefix + "async-compression-auto-on")
+
+    try:
+        await ns.delete_all()
+    except turbopuffer.NotFoundError:
+        pass
+
+    await ns.write(
+        upsert_rows=[
+            {
+                "id": 1,
+                "vector": [0.1] * 1024,
+                "title": "test doc",
+            },
+        ],
+        distance_metric="euclidean_squared",
+    )
+
+    # This request is large enough to be compressed.
+    result = await ns.query(
+        rank_by=("vector", "ANN", [0.1] * 1024),
+        top_k=1,
+        include_attributes=True,
+    )
+
+    perf = result.performance
+    assert perf.client_total_ms > 0
+    assert perf.client_compress_ms > 0
+    assert perf.client_response_ms is not None and perf.client_response_ms > 0
+    assert perf.client_body_read_ms is not None and perf.client_body_read_ms > 0
+    assert perf.client_deserialize_ms > 0
+
+
+async def test_async_compression_auto_off(async_tpuf: AsyncTurbopuffer):
+    ns = async_tpuf.namespace(test_prefix + "async-compression-auto-off")
+
+    try:
+        await ns.delete_all()
+    except turbopuffer.NotFoundError:
+        pass
+
+    await ns.write(
+        upsert_rows=[
+            {
+                "id": 1,
+                "vector": [0.1],
+                "title": "test doc",
+            },
+        ],
+        distance_metric="euclidean_squared",
+    )
+
+    # This request is too small to be compressed.
+    result = await ns.query(
+        rank_by=("vector", "ANN", [0.1]),
+        top_k=1,
+        include_attributes=True,
+    )
+
+    perf = result.performance
+    assert perf.client_total_ms > 0
+    assert perf.client_compress_ms == 0
+    assert perf.client_response_ms is not None and perf.client_response_ms > 0
+    assert perf.client_body_read_ms is not None and perf.client_body_read_ms > 0
+    assert perf.client_deserialize_ms > 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1033,7 +1033,7 @@ class TestAsyncTurbopuffer:
         ):
             client.copy(set_default_query={}, default_query={"foo": "Bar"})
 
-    def test_copy_signature(self, client: TurbopufferStd) -> None:
+    def test_copy_signature(self, client: Turbopuffer) -> None:
         # ensure the same parameters that can be passed to the client are defined in the `.copy()` method
         init_signature = inspect.signature(
             # mypy doesn't like that we access the `__init__` property.


### PR DESCRIPTION
Also restore request compression for large requests, and client-side performance metrics.

Sync performance:

```
| Benchmark      | bench-baseline | bench-stainless-base   | bench-stainless-opt    | bench-stainless-opt2   | bench-stainless-opt3   |
+================+================+========================+========================+========================+========================+
| upsert         | 1.88 sec       | 896 ms: 2.09x faster   | 1.16 sec: 1.62x faster | 1.12 sec: 1.68x faster | 1.13 sec: 1.66x faster |
+----------------+----------------+------------------------+------------------------+------------------------+------------------------+
| query          | 265 ms         | 277 ms: 1.04x slower   | 340 ms: 1.28x slower   | 252 ms: 1.05x faster   | 244 ms: 1.08x faster   |
+----------------+----------------+------------------------+------------------------+------------------------+------------------------+
| query_scale    | 2.68 sec       | 4.71 sec: 1.76x slower | 4.81 sec: 1.80x slower | 3.37 sec: 1.26x slower | 3.32 sec: 1.24x slower |
+----------------+----------------+------------------------+------------------------+------------------------+------------------------+
| Geometric mean | (ref)          | 1.05x faster           | 1.12x slower           | 1.12x faster           | 1.13x faster           |
+----------------+----------------+------------------------+------------------------+------------------------+------------------------+
```

Base was before this PR. `opt` was the failed experiment to use `urllib3` transports. `opt2` was `urllib3` plus `orjson`. `opt3` is the default httpx transport, plus request compression, plus `orjson`.

There's still a modest slowdown for `query_scale`, but it's tolerable, and the other two are meaningfully faster—`upsert` especially!

Async performance:

```
+----------------+----------------+------------------------+
| Benchmark      | bench-baseline | bench-experiment       |
+================+================+========================+
| query_scale    | 4.34 sec       | 2.57 sec: 1.69x faster |
+----------------+----------------+------------------------+
| Geometric mean | (ref)          | 1.13x faster           |
+----------------+----------------+------------------------+

Benchmark hidden because not significant (2): upsert, query
```

Unlike the sync client, there's no OG async client.

`baseline` is the built in async transport; `experiment` is the aiohttp transport. No significant perf difference in `upsert` or `query`, but the `query_scale` benchmark is a good bit better with the aiohttp transport. Note that I had to disable compression in the aiohttp transport to get a fair comparison (the baseline doesn't do compression), so the absolute speed of the aiohttp transport is not representative of the real world.

Fastest sync vs async performance:

```
+----------------+----------------------+------------------------+
| Benchmark      | bench-stainless-opt3 | bench-experiment       |
+================+======================+========================+
| query          | 244 ms               | 256 ms: 1.05x slower   |
+----------------+----------------------+------------------------+
| query_scale    | 3.32 sec             | 3.00 sec: 1.11x faster |
+----------------+----------------------+------------------------+
| Geometric mean | (ref)                | 1.03x faster           |
+----------------+----------------------+------------------------+

Benchmark hidden because not significant (1): upsert
```

They're basically equivalent in performance.