### PR TITLE
fix: mark urllib3 optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ authors = [
 dependencies = [
     "httpx>=0.23.0, <1",
     "aiohttp>=3.12.11, <4",
-    "urllib3>=2.4.0, <3",
     "pydantic>=1.9.0, <3",
     "pybase64>=1.4.1, <2",
     "typing-extensions>=4.13, <5",
@@ -38,6 +37,7 @@ classifiers = [
 
 [project.optional-dependencies]
 fast = ["orjson>=3.10.18, <4"]
+urllib3 = ["urllib3>=2.4.0, <3"]
 
 [project.urls]
 Homepage = "https://github.com/turbopuffer/turbopuffer-python"


### PR DESCRIPTION
Since it's not required by default, and the recent version is causing trouble for some potential users.