### PR TITLE
fix: restore support for Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 dependencies = [
     "httpx>=0.23.0, <1",
-    "aiohttp>=3.12.11, <4",
+    "aiohttp>=3.10.11, <4",
     "pydantic>=1.9.0, <3",
     "pybase64>=1.4.1, <2",
     "typing-extensions>=4.13, <5",
@@ -36,8 +36,8 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-fast = ["orjson>=3.10.18, <4"]
-urllib3 = ["urllib3>=2.4.0, <3"]
+fast = ["orjson>=3.10.15, <4"]
+urllib3 = ["urllib3>=2.2.3, <3"]
 
 [project.urls]
 Homepage = "https://github.com/turbopuffer/turbopuffer-python"


### PR DESCRIPTION
The minimum versions for aiohttp, orjson, and urllib3 needed to be loosened.