### PR TITLE
fix: don't run grouped tests in parallel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ replacement = '[\1](https://github.com/turbopuffer/turbopuffer-python/tree/main/
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--tb=short -n auto"
+addopts = "--tb=short -n auto --dist loadgroup"
 xfail_strict = true
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"


### PR DESCRIPTION
These tests rely on running in sequence on the same worker.