### PR TITLE
fix: don't require region unless baseUrl contains {region} placeholder

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -53,7 +53,6 @@ else
 fi
 
 export DEFER_PYDANTIC_BUILD=false
-export TURBOPUFFER_REGION=gcp-us-central1
 
 echo "==> Running tests"
 rye run pytest "$@"

--- a/src/turbopuffer/_base_client.py
+++ b/src/turbopuffer/_base_client.py
@@ -675,10 +675,6 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
     def base_url(self) -> URL:
         return self._base_url
 
-    @base_url.setter
-    def base_url(self, url: URL | str) -> None:
-        self._base_url = self._enforce_trailing_slash(url if isinstance(url, URL) else URL(url))
-
     def platform_headers(self) -> Dict[str, str]:
         # the actual implementation is in a separate `lru_cache` decorated
         # function because adding `lru_cache` to methods will leak memory

--- a/src/turbopuffer/_client.py
+++ b/src/turbopuffer/_client.py
@@ -105,7 +105,7 @@ class Turbopuffer(SyncAPIClient):
 
         This automatically infers the following arguments from their corresponding environment variables if they are not provided:
         - `api_key` from `TURBOPUFFER_API_KEY`
-        - `region` from `TURBOPUFFER_REGION`
+        - `region` from `TURBOPUFFER_REGION` (unless base_url is overridden)
         """
         if api_key is None:
             api_key = os.environ.get("TURBOPUFFER_API_KEY")
@@ -124,7 +124,20 @@ class Turbopuffer(SyncAPIClient):
         if base_url is None:
             base_url = os.environ.get("TURBOPUFFER_BASE_URL")
         if base_url is None:
-            base_url = f"https://{region}.turbopuffer.com"
+            base_url = "https://{region}.turbopuffer.com"
+        self.original_base_url = base_url
+
+        has_region_placeholder = "{region}" in str(base_url)
+        if has_region_placeholder:
+            if region is None:
+                raise TurbopufferError(
+                    f"region is required, but not set (baseUrl has a {{region}} placeholder: {base_url})"
+                )
+            base_url = str(base_url).replace("{region}", region)
+        elif region is not None:
+            raise TurbopufferError(
+                f"region is set, but would be ignored (baseUrl does not contain {{region}} placeholder: {base_url})"
+            )
 
         super().__init__(
             version=__version__,
@@ -206,7 +219,7 @@ class Turbopuffer(SyncAPIClient):
             api_key=api_key or self.api_key,
             region=region or self.region,
             default_namespace=default_namespace or self.default_namespace,
-            base_url=base_url or self.base_url,
+            base_url=base_url or self.original_base_url,
             timeout=self.timeout if isinstance(timeout, NotGiven) else timeout,
             http_client=http_client,
             max_retries=max_retries if is_given(max_retries) else self.max_retries,
@@ -351,7 +364,7 @@ class AsyncTurbopuffer(AsyncAPIClient):
 
         This automatically infers the following arguments from their corresponding environment variables if they are not provided:
         - `api_key` from `TURBOPUFFER_API_KEY`
-        - `region` from `TURBOPUFFER_REGION`
+        - `region` from `TURBOPUFFER_REGION` (unless base_url is overridden)
         """
         if api_key is None:
             api_key = os.environ.get("TURBOPUFFER_API_KEY")
@@ -370,7 +383,20 @@ class AsyncTurbopuffer(AsyncAPIClient):
         if base_url is None:
             base_url = os.environ.get("TURBOPUFFER_BASE_URL")
         if base_url is None:
-            base_url = f"https://{region}.turbopuffer.com"
+            base_url = "https://{region}.turbopuffer.com"
+        self.original_base_url = base_url
+
+        has_region_placeholder = "{region}" in str(base_url)
+        if has_region_placeholder:
+            if region is None:
+                raise TurbopufferError(
+                    f"region is required, but not set (baseUrl has a {{region}} placeholder: {base_url})"
+                )
+            base_url = str(base_url).replace("{region}", region)
+        elif region is not None:
+            raise TurbopufferError(
+                f"region is set, but would be ignored (baseUrl does not contain {{region}} placeholder: {base_url})"
+            )
 
         super().__init__(
             version=__version__,
@@ -452,7 +478,7 @@ class AsyncTurbopuffer(AsyncAPIClient):
             api_key=api_key or self.api_key,
             region=region or self.region,
             default_namespace=default_namespace or self.default_namespace,
-            base_url=base_url or self.base_url,
+            base_url=base_url or self.original_base_url,
             timeout=self.timeout if isinstance(timeout, NotGiven) else timeout,
             http_client=http_client,
             max_retries=max_retries if is_given(max_retries) else self.max_retries,

--- a/tests/custom/conftest.py
+++ b/tests/custom/conftest.py
@@ -7,10 +7,10 @@ from turbopuffer import Turbopuffer, AsyncTurbopuffer
 
 @pytest.fixture(scope="session")
 def tpuf() -> Iterator[Turbopuffer]:
-    with Turbopuffer() as tpuf:
+    with Turbopuffer(region="gcp-us-central1") as tpuf:
         yield tpuf
 
 
 @pytest.fixture(scope="session")
 async def async_tpuf() -> AsyncIterator[AsyncTurbopuffer]:
-    yield AsyncTurbopuffer()
+    yield AsyncTurbopuffer(region="gcp-us-central1")


### PR DESCRIPTION
This has tripped up a few BYOC customers.