### PR TITLE
fix: serialize datetime objects when orjson isn't installed

### DIFF
--- a/src/turbopuffer/lib/json.py
+++ b/src/turbopuffer/lib/json.py
@@ -10,8 +10,17 @@ try:
 
 except ImportError:
     import json
+    from datetime import datetime
+    from typing_extensions import override
 
     loads = json.loads
 
     def dumps(obj: Any) -> bytes:
-        return json.dumps(obj).encode()
+        return json.dumps(obj, cls=_DateTimeEncoder).encode()
+
+    class _DateTimeEncoder(json.JSONEncoder):
+        @override
+        def default(self, o: Any) -> Any:
+            if isinstance(o, datetime):
+                return o.isoformat()
+            return super().default(o)


### PR DESCRIPTION
orjson natively supports serializing datetime objects, but the builtin json package (which is used when someone installs without the [fast] option) does not.

For parity with orjson, plumb a custom encoder to the builtin json package that automatically serializes datetime objects. That way datetime serialization we can rely on datetime serialization being automatic regardless of how users install turbopuffer.