### PR TITLE
fix: use ThreadedResolver for default async client

### DIFF
--- a/src/turbopuffer/_base_client.py
+++ b/src/turbopuffer/_base_client.py
@@ -34,7 +34,9 @@ from typing_extensions import Literal, override, get_origin
 import anyio
 import httpx
 import distro
+import aiohttp
 import pydantic
+import aiohttp.resolver
 from httpx import URL
 from aiohttp import ClientSession
 from pydantic import PrivateAttr
@@ -1393,7 +1395,17 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
-        kwargs.setdefault("transport", AiohttpTransport(client=lambda: ClientSession()))
+        # Force use of the ThreadedResolver even if aiodns is installed.
+        # We received a report of the aiodns resolver caching negative
+        # responses too long.
+        kwargs.setdefault(
+            "transport",
+            AiohttpTransport(
+                client=lambda: ClientSession(
+                    connector=aiohttp.TCPConnector(resolver=aiohttp.resolver.ThreadedResolver()),
+                )
+            ),
+        )
         super().__init__(**kwargs)
 
 


### PR DESCRIPTION
Force use of the ThreadedResolver even if aiodns is installed. We received a report of the aiodns resolver caching negative responses too long.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes DNS resolution behavior for the default async HTTP client, which could affect connectivity or performance in some environments despite being a targeted fix.
> 
> **Overview**
> **Default async HTTP client now forces aiohttp’s `ThreadedResolver`.** `_DefaultAsyncHttpxClient` constructs its `AiohttpTransport` with an `aiohttp.TCPConnector(resolver=ThreadedResolver())`, avoiding the `aiodns` resolver even when installed to mitigate overly aggressive negative-DNS caching.
> 
> Adds the required `aiohttp`/`aiohttp.resolver` imports to support the new connector configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f834ec25738323726926a8ebefe32694dfcfd8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->