### PR TITLE
perf: increase default connection idle timeout to 60s

### DIFF
--- a/src/turbopuffer/_base_client.py
+++ b/src/turbopuffer/_base_client.py
@@ -1402,7 +1402,17 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
             "transport",
             AiohttpTransport(
                 client=lambda: ClientSession(
-                    connector=aiohttp.TCPConnector(resolver=aiohttp.resolver.ThreadedResolver()),
+                    connector=aiohttp.TCPConnector(
+                        keepalive_timeout=kwargs["limits"].keepalive_expiry,
+                        resolver=aiohttp.resolver.ThreadedResolver(),
+                        **(
+                            {
+                                "limit": kwargs["limits"].max_connections,
+                            }
+                            if kwargs["limits"].max_connections is not None
+                            else {}
+                        ),
+                    ),
                 )
             ),
         )

--- a/src/turbopuffer/_base_client.py
+++ b/src/turbopuffer/_base_client.py
@@ -1409,11 +1409,13 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         super().__init__(**kwargs)
 
 
+# NOTE(benesch): unused in favor of _DefaultAsyncHttpxClient, which already
+# uses AiohttpTransport.
 try:
     import httpx_aiohttp
 except ImportError:
 
-    class _DefaultAioHttpClient(httpx.AsyncClient):
+    class _DefaultAioHttpClient(httpx.AsyncClient):  # type: ignore
         def __init__(self, **_kwargs: Any) -> None:
             raise RuntimeError("To use the aiohttp client you must have installed the package with the `aiohttp` extra")
 else:
@@ -1440,7 +1442,7 @@ if TYPE_CHECKING:
     """An alias to `httpx.AsyncClient` that changes the default HTTP transport to `aiohttp`."""
 else:
     DefaultAsyncHttpxClient = _DefaultAsyncHttpxClient
-    DefaultAioHttpClient = _DefaultAioHttpClient
+    DefaultAioHttpClient = _DefaultAsyncHttpxClient  # see note on _DefaultAioHttpClient above
 
 
 class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):

--- a/src/turbopuffer/_constants.py
+++ b/src/turbopuffer/_constants.py
@@ -8,7 +8,11 @@ OVERRIDE_CAST_TO_HEADER = "____stainless_override_cast_to"
 # default timeout is 1 minute
 DEFAULT_TIMEOUT = httpx.Timeout(timeout=60, connect=5.0)
 DEFAULT_MAX_RETRIES = 4
-DEFAULT_CONNECTION_LIMITS = httpx.Limits(max_connections=512, max_keepalive_connections=512)
+DEFAULT_CONNECTION_LIMITS = httpx.Limits(
+    max_connections=512,
+    max_keepalive_connections=512,
+    keepalive_expiry=60.0,
+)
 
 INITIAL_RETRY_DELAY = 0.25
 MAX_RETRY_DELAY = 8.0

--- a/tests/api_resources/test_namespaces.py
+++ b/tests/api_resources/test_namespaces.py
@@ -375,7 +375,7 @@ class TestNamespaces:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     def test_method_update_metadata(self, client: Turbopuffer) -> None:
-        namespace = client.namespaces.update_metadata(
+        namespace = client.namespace("namespace").update_metadata(
             namespace="namespace",
         )
         assert_matches_type(NamespaceMetadata, namespace, path=["response"])
@@ -383,7 +383,7 @@ class TestNamespaces:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     def test_method_update_metadata_with_all_params(self, client: Turbopuffer) -> None:
-        namespace = client.namespaces.update_metadata(
+        namespace = client.namespace("namespace").update_metadata(
             namespace="namespace",
             pinning=True,
         )
@@ -392,7 +392,7 @@ class TestNamespaces:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     def test_raw_response_update_metadata(self, client: Turbopuffer) -> None:
-        response = client.namespaces.with_raw_response.update_metadata(
+        response = client.namespace("namespace").with_raw_response.update_metadata(
             namespace="namespace",
         )
 
@@ -404,7 +404,7 @@ class TestNamespaces:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     def test_streaming_response_update_metadata(self, client: Turbopuffer) -> None:
-        with client.namespaces.with_streaming_response.update_metadata(
+        with client.namespace("namespace").with_streaming_response.update_metadata(
             namespace="namespace",
         ) as response:
             assert not response.is_closed
@@ -419,7 +419,7 @@ class TestNamespaces:
     @parametrize
     def test_path_params_update_metadata(self, client: Turbopuffer) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `namespace` but received ''"):
-            client.namespaces.with_raw_response.update_metadata(
+            client.namespace("namespace").with_raw_response.update_metadata(
                 namespace="",
             )
 
@@ -897,16 +897,13 @@ class TestAsyncNamespaces:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     async def test_method_update_metadata(self, async_client: AsyncTurbopuffer) -> None:
-        namespace = await async_client.namespaces.update_metadata(
-            namespace="namespace",
-        )
+        namespace = await async_client.namespace("namespace").update_metadata()
         assert_matches_type(NamespaceMetadata, namespace, path=["response"])
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     async def test_method_update_metadata_with_all_params(self, async_client: AsyncTurbopuffer) -> None:
-        namespace = await async_client.namespaces.update_metadata(
-            namespace="namespace",
+        namespace = await async_client.namespace("namespace").update_metadata(
             pinning=True,
         )
         assert_matches_type(NamespaceMetadata, namespace, path=["response"])
@@ -914,9 +911,7 @@ class TestAsyncNamespaces:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     async def test_raw_response_update_metadata(self, async_client: AsyncTurbopuffer) -> None:
-        response = await async_client.namespaces.with_raw_response.update_metadata(
-            namespace="namespace",
-        )
+        response = await async_client.namespace("namespace").with_raw_response.update_metadata()
 
         assert response.is_closed is True
         assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -926,9 +921,7 @@ class TestAsyncNamespaces:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     async def test_streaming_response_update_metadata(self, async_client: AsyncTurbopuffer) -> None:
-        async with async_client.namespaces.with_streaming_response.update_metadata(
-            namespace="namespace",
-        ) as response:
+        async with async_client.namespace("namespace").with_streaming_response.update_metadata() as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
 
@@ -941,7 +934,7 @@ class TestAsyncNamespaces:
     @parametrize
     async def test_path_params_update_metadata(self, async_client: AsyncTurbopuffer) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `namespace` but received ''"):
-            await async_client.namespaces.with_raw_response.update_metadata(
+            await async_client.namespace("namespace").with_raw_response.update_metadata(
                 namespace="",
             )
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default connection pooling/keepalive behavior for async requests, which can affect resource usage and connection reuse under load. Risk is moderate because it touches low-level HTTP transport defaults, but scope is small and test updates are mechanical.
> 
> **Overview**
> Increases the SDK’s default connection idle timeout by setting `DEFAULT_CONNECTION_LIMITS.keepalive_expiry` to 60s, and wires this value into the aiohttp `TCPConnector` via `keepalive_timeout` for the default async client.
> 
> Also aligns the aiohttp connector’s max connection limit with `httpx.Limits.max_connections` (when set), and updates `DefaultAioHttpClient` to reuse `_DefaultAsyncHttpxClient` instead of the separate `_DefaultAioHttpClient` implementation. Namespace tests are adjusted to use the `client.namespace("...")` accessor for `update_metadata` calls (sync/async).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 873f1304e31c92f9db2082a39b37164aaecbc2b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->