### PR TITLE
docs: document v2.0 breaking changes in UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -67,10 +67,23 @@ list of changes.
   A new `{"mode": "default"}` variant lets you migrate a namespace from CMEK
   to default encryption.
 
-- The `RankByVector` and `RankBySparseVector` type aliases have been renamed
-  to `RankByAnn` and `RankBySparseKnn`. The wire-format strings (`"ANN"` and
-  `"SparseKNN"`) are unchanged, so any code that passes plain tuples or lists
-  to `rank_by` is unaffected.
+- The `RankByVector` type alias has been renamed to `RankByAnn`.
+
+  Old:
+
+  ```py
+  from turbopuffer.types import RankByVector
+
+  rank_by: RankByVector = ("vector", "ANN", [0.1, 0.2])
+  ```
+
+  New:
+
+  ```py
+  from turbopuffer.types import RankByAnn
+
+  rank_by: RankByAnn = ("vector", "ANN", [0.1, 0.2])
+  ```
 
 ## v1.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -67,6 +67,11 @@ list of changes.
   A new `{"mode": "default"}` variant lets you migrate a namespace from CMEK
   to default encryption.
 
+- The `RankByVector` and `RankBySparseVector` type aliases have been renamed
+  to `RankByAnn` and `RankBySparseKnn`. The wire-format strings (`"ANN"` and
+  `"SparseKNN"`) are unchanged, so any code that passes plain tuples or lists
+  to `rank_by` is unaffected.
+
 ## v1.0
 
 No significant changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,47 @@ list of changes.
 
 ## v2.0
 
+- The `RankByVector` type alias has been renamed to `RankByAnn`.
+
+  Old:
+
+  ```py
+  from turbopuffer.types import RankByVector
+
+  rank_by: RankByVector = ("vector", "ANN", [0.1, 0.2])
+  ```
+
+  New:
+
+  ```py
+  from turbopuffer.types import RankByAnn
+
+  rank_by: RankByAnn = ("vector", "ANN", [0.1, 0.2])
+  ```
+
+- The `encryption` parameter has been restructured.
+
+  Old:
+
+  ```py
+  tpuf.namespace("ns").write(
+      upsert_rows=[...],
+      encryption={"cmek": {"key_name": "..."}},
+  )
+  ```
+
+  New:
+
+  ```py
+  tpuf.namespace("ns").write(
+      upsert_rows=[...],
+      encryption={"mode": "customer-managed", "key_name": "..."},
+  )
+  ```
+
+  A new `{"mode": "default"}` variant lets you migrate a namespace from CMEK
+  to default encryption.
+
 - The `copy_from_namespace` parameter to the `write` method has been replaced
   with a dedicated `copy_from` method.
 
@@ -42,47 +83,6 @@ list of changes.
 
   ```py
   tpuf.namespace("ns").branch_from(source_namespace="src")
-  ```
-
-- The `encryption` parameter has been restructured.
-
-  Old:
-
-  ```py
-  tpuf.namespace("ns").write(
-      upsert_rows=[...],
-      encryption={"cmek": {"key_name": "..."}},
-  )
-  ```
-
-  New:
-
-  ```py
-  tpuf.namespace("ns").write(
-      upsert_rows=[...],
-      encryption={"mode": "customer-managed", "key_name": "..."},
-  )
-  ```
-
-  A new `{"mode": "default"}` variant lets you migrate a namespace from CMEK
-  to default encryption.
-
-- The `RankByVector` type alias has been renamed to `RankByAnn`.
-
-  Old:
-
-  ```py
-  from turbopuffer.types import RankByVector
-
-  rank_by: RankByVector = ("vector", "ANN", [0.1, 0.2])
-  ```
-
-  New:
-
-  ```py
-  from turbopuffer.types import RankByAnn
-
-  rank_by: RankByAnn = ("vector", "ANN", [0.1, 0.2])
   ```
 
 ## v1.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,50 @@ This document describes the notable breaking changes, if any, in each version of
 the Python client. See [CHANGELOG.md](./CHANGELOG.md) for a comprehensive
 list of changes.
 
+## v2.0
+
+- The `copy_from_namespace` parameter to the `write` method has been replaced
+  with a dedicated `copy_from` method.
+
+  Old:
+
+  ```py
+  tpuf.namespace("ns").write(
+      copy_from_namespace={
+          "source_namespace": "src",
+          "source_region": "gcp-us-central1",
+      },
+  )
+  ```
+
+  New:
+
+  ```py
+  tpuf.namespace("ns").copy_from(
+      source_namespace="src",
+      source_region="gcp-us-central1",
+  )
+  ```
+
+- The `branch_from_namespace` parameter to the `write` method has been replaced
+  with a dedicated `branch_from` method.
+
+  Old:
+
+  ```py
+  tpuf.namespace("ns").write(branch_from_namespace="src")
+  ```
+
+  New:
+
+  ```py
+  tpuf.namespace("ns").branch_from(source_namespace="src")
+  ```
+
+## v1.0
+
+No significant changes.
+
 ## v0.5
 
 v0.5 is a complete rewrite of the Python client. The new client is

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,9 +44,7 @@ list of changes.
   tpuf.namespace("ns").branch_from(source_namespace="src")
   ```
 
-- The `encryption` parameter has been restructured. A new `{"mode": "default"}`
-  variant lets you explicitly opt out of CMEK on writes to a CMEK-enabled
-  namespace.
+- The `encryption` parameter has been restructured.
 
   Old:
 
@@ -65,6 +63,9 @@ list of changes.
       encryption={"mode": "customer-managed", "key_name": "..."},
   )
   ```
+
+  A new `{"mode": "default"}` variant lets you explicitly opt out of CMEK on
+  writes to a CMEK-enabled namespace.
 
 ## v1.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,10 +44,9 @@ list of changes.
   tpuf.namespace("ns").branch_from(source_namespace="src")
   ```
 
-- The `encryption` parameter has been restructured. The `cmek` wrapper has been
-  removed in favor of a flat object with a required `mode` discriminator. A new
-  `{"mode": "default"}` variant lets you explicitly opt out of CMEK on writes
-  to a CMEK-enabled namespace.
+- The `encryption` parameter has been restructured. A new `{"mode": "default"}`
+  variant lets you explicitly opt out of CMEK on writes to a CMEK-enabled
+  namespace.
 
   Old:
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -64,8 +64,8 @@ list of changes.
   )
   ```
 
-  A new `{"mode": "default"}` variant lets you explicitly opt out of CMEK on
-  writes to a CMEK-enabled namespace.
+  A new `{"mode": "default"}` variant lets you migrate a namespace from CMEK
+  to default encryption.
 
 ## v1.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,6 +44,29 @@ list of changes.
   tpuf.namespace("ns").branch_from(source_namespace="src")
   ```
 
+- The `encryption` parameter has been restructured. The `cmek` wrapper has been
+  removed in favor of a flat object with a required `mode` discriminator. A new
+  `{"mode": "default"}` variant lets you explicitly opt out of CMEK on writes
+  to a CMEK-enabled namespace.
+
+  Old:
+
+  ```py
+  tpuf.namespace("ns").write(
+      upsert_rows=[...],
+      encryption={"cmek": {"key_name": "..."}},
+  )
+  ```
+
+  New:
+
+  ```py
+  tpuf.namespace("ns").write(
+      upsert_rows=[...],
+      encryption={"mode": "customer-managed", "key_name": "..."},
+  )
+  ```
+
 ## v1.0
 
 No significant changes.


### PR DESCRIPTION
Adds entries to UPGRADING.md describing the v2.0 breaking changes inferred from the docs samples:

- `copy_from_namespace` write parameter replaced by a dedicated `copy_from` method.
- `branch_from_namespace` write parameter replaced by a dedicated `branch_from` method.

Also adds a stub v1.0 entry noting no significant changes.