### PR TITLE
feat: transparent async polling

### DIFF
--- a/src/turbopuffer/_client.py
+++ b/src/turbopuffer/_client.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Mapping
+from typing import Any, Type, Mapping
 from typing_extensions import Self, override
 
 import httpx
 
 from . import _exceptions
 from ._qs import Querystring
+from .lib import respond_async
 from .types import client_namespaces_params
 from ._types import (
     Body,
@@ -18,6 +19,7 @@ from ._types import (
     Headers,
     Timeout,
     NotGiven,
+    ResponseT,
     Transport,
     ProxiesTypes,
     RequestOptions,
@@ -30,6 +32,7 @@ from ._utils import (
     maybe_transform,
     get_async_library,
 )
+from ._models import FinalRequestOptions
 from ._version import __version__
 from ._response import (
     to_raw_response_wrapper,
@@ -341,6 +344,35 @@ class Turbopuffer(SyncAPIClient):
             return _exceptions.InternalServerError(err_msg, response=response, body=body)
         return APIStatusError(err_msg, response=response, body=body)
 
+    @override
+    def _prepare_options(self, options: FinalRequestOptions) -> FinalRequestOptions:
+        respond_async.prepare_options(options)
+        return options
+
+    @override
+    def _process_response(
+        self,
+        *,
+        cast_to: Type[ResponseT],
+        options: FinalRequestOptions,
+        response: httpx.Response,
+        stream: bool,
+        stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
+        retries_taken: int = 0,
+    ) -> ResponseT:
+        response = respond_async.process_response(response=response, client=self)
+        if response.is_error:
+            raise self._make_status_error_from_response(response)
+
+        return super()._process_response(
+            cast_to=cast_to,
+            options=options,
+            response=response,
+            stream=stream,
+            stream_cls=stream_cls,
+            retries_taken=retries_taken,
+        )
+
 
 class AsyncTurbopuffer(AsyncAPIClient):
     with_raw_response: AsyncTurbopufferWithRawResponse
@@ -613,6 +645,35 @@ class AsyncTurbopuffer(AsyncAPIClient):
         if response.status_code >= 500:
             return _exceptions.InternalServerError(err_msg, response=response, body=body)
         return APIStatusError(err_msg, response=response, body=body)
+
+    @override
+    async def _prepare_options(self, options: FinalRequestOptions) -> FinalRequestOptions:
+        respond_async.prepare_options(options)
+        return options
+
+    @override
+    async def _process_response(
+        self,
+        *,
+        cast_to: Type[ResponseT],
+        options: FinalRequestOptions,
+        response: httpx.Response,
+        stream: bool,
+        stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
+        retries_taken: int = 0,
+    ) -> ResponseT:
+        response = await respond_async.process_response_aio(response=response, client=self)
+        if response.is_error:
+            raise self._make_status_error_from_response(response)
+
+        return await super()._process_response(
+            cast_to=cast_to,
+            options=options,
+            response=response,
+            stream=stream,
+            stream_cls=stream_cls,
+            retries_taken=retries_taken,
+        )
 
 
 class TurbopufferWithRawResponse:

--- a/src/turbopuffer/_client.py
+++ b/src/turbopuffer/_client.py
@@ -360,7 +360,7 @@ class Turbopuffer(SyncAPIClient):
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
         retries_taken: int = 0,
     ) -> ResponseT:
-        response = respond_async.process_response(response=response, client=self)
+        response = respond_async.process_response(response=response, client=self, options=options)
         if response.is_error:
             raise self._make_status_error_from_response(response)
 
@@ -662,7 +662,7 @@ class AsyncTurbopuffer(AsyncAPIClient):
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
         retries_taken: int = 0,
     ) -> ResponseT:
-        response = await respond_async.process_response_aio(response=response, client=self)
+        response = await respond_async.process_response_aio(response=response, client=self, options=options)
         if response.is_error:
             raise self._make_status_error_from_response(response)
 

--- a/src/turbopuffer/lib/respond_async.py
+++ b/src/turbopuffer/lib/respond_async.py
@@ -13,7 +13,7 @@ Wired in via `_prepare_options` and `_process_response` overrides on
 from __future__ import annotations
 
 import time
-from typing import Any, Optional
+from typing import Any, Union, Optional
 from typing_extensions import Literal
 
 import anyio
@@ -21,9 +21,10 @@ import httpx
 import pydantic
 
 from .._types import omit
+from .._utils import is_given
 from .._compat import parse_obj
 from .._models import BaseModel, FinalRequestOptions
-from .._exceptions import APIResponseValidationError
+from .._exceptions import APITimeoutError, APIResponseValidationError
 from .._base_client import SyncAPIClient, AsyncAPIClient
 
 HEADER_PREFER = "prefer"
@@ -32,6 +33,7 @@ HEADER_LOCATION = "location"
 RESPOND_ASYNC = "respond-async"
 
 POLL_INTERVAL_SECS = 1
+POLL_REQUEST_TIMEOUT_SECS = 60.0
 
 
 def prepare_options(options: FinalRequestOptions) -> None:
@@ -44,48 +46,68 @@ def prepare_options(options: FinalRequestOptions) -> None:
     options.headers = {**existing, HEADER_PREFER: RESPOND_ASYNC}
 
 
-def process_response(*, response: httpx.Response, client: SyncAPIClient) -> httpx.Response:
+def process_response(
+    *,
+    response: httpx.Response,
+    client: SyncAPIClient,
+    options: FinalRequestOptions,
+) -> httpx.Response:
     if not _respond_async_applied(response):
         return response
 
     orig_request = response.request
     location = response.headers[HEADER_LOCATION]
+    timeout = _Timeout(options, client.timeout)
 
     while True:
+        if timeout.remaining() == 0:
+            raise APITimeoutError(request=orig_request)
+
         poll = client.request(
             cast_to=httpx.Response,
             options=FinalRequestOptions.construct(
                 method="get",
                 url=location,
                 headers={HEADER_PREFER: omit},
+                timeout=timeout.poll_timeout(),
             ),
         )
         if resp := _resolve_poll_response(poll, orig_request):
             return resp
 
-        time.sleep(POLL_INTERVAL_SECS)
+        time.sleep(timeout.sleep_duration())
 
 
-async def process_response_aio(*, response: httpx.Response, client: AsyncAPIClient) -> httpx.Response:
+async def process_response_aio(
+    *,
+    response: httpx.Response,
+    client: AsyncAPIClient,
+    options: FinalRequestOptions,
+) -> httpx.Response:
     if not _respond_async_applied(response):
         return response
 
     orig_request = response.request
     location = response.headers[HEADER_LOCATION]
+    timeout = _Timeout(options, client.timeout)
 
     while True:
+        if timeout.remaining() == 0:
+            raise APITimeoutError(request=orig_request)
+
         poll = await client.request(
             cast_to=httpx.Response,
             options=FinalRequestOptions.construct(
                 method="get",
                 url=location,
                 headers={HEADER_PREFER: omit},
+                timeout=timeout.poll_timeout(),
             ),
         )
         if resp := _resolve_poll_response(poll, orig_request):
             return resp
 
-        await anyio.sleep(POLL_INTERVAL_SECS)
+        await anyio.sleep(timeout.sleep_duration())
 
 
 def _respond_async_applied(response: httpx.Response) -> bool:
@@ -138,3 +160,26 @@ def _resolve_poll_response(response: httpx.Response, request: httpx.Request) -> 
         json=error.detail,
         request=request,
     )
+
+
+class _Timeout:
+    """Timeout tracking for async polling."""
+
+    def __init__(self, request_options: FinalRequestOptions, client_timeout: Union[float, httpx.Timeout, None]):
+        timeout = request_options.timeout if is_given(request_options.timeout) else client_timeout
+        if isinstance(timeout, httpx.Timeout):
+            timeout = timeout.read
+
+        if timeout is None:
+            self.deadline = float("inf")
+        else:
+            self.deadline = time.monotonic() + timeout
+
+    def remaining(self) -> float:
+        return max(self.deadline - time.monotonic(), 0)
+
+    def poll_timeout(self) -> float:
+        return min(self.remaining(), POLL_REQUEST_TIMEOUT_SECS)
+
+    def sleep_duration(self) -> float:
+        return min(self.remaining(), POLL_INTERVAL_SECS)

--- a/src/turbopuffer/lib/respond_async.py
+++ b/src/turbopuffer/lib/respond_async.py
@@ -1,0 +1,140 @@
+"""
+Support for transparent polling of async tpuf APIs.
+
+Every API request is stamped with `prefer: respond-async`. If the server
+applies the preference (i.e. responds with `202 Accepted` +
+`preference-applied: respond-async`) the SDK polls that URL until the operation
+finishes and returns the final result as if the API call had been synchronous.
+
+Wired in via `_prepare_options` and `_process_response` overrides on
+`Turbopuffer`/`AsyncTurbopuffer`.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+from typing_extensions import Literal
+
+import anyio
+import httpx
+import pydantic
+
+from .._types import omit
+from .._compat import parse_obj
+from .._models import BaseModel, FinalRequestOptions
+from .._exceptions import APIResponseValidationError
+from .._base_client import SyncAPIClient, AsyncAPIClient
+
+HEADER_PREFER = "prefer"
+HEADER_PREFERENCE_APPLIED = "preference-applied"
+HEADER_LOCATION = "location"
+RESPOND_ASYNC = "respond-async"
+
+POLL_INTERVAL_SECS = 1
+
+
+def prepare_options(options: FinalRequestOptions) -> None:
+    existing = options.headers or {}
+
+    # Don't overwrite an existing `prefer` header. This allows the caller to disable async mode.
+    if any(k.lower() == HEADER_PREFER for k in existing):
+        return
+
+    options.headers = {**existing, HEADER_PREFER: RESPOND_ASYNC}
+
+
+def process_response(*, response: httpx.Response, client: SyncAPIClient) -> httpx.Response:
+    if not _respond_async_applied(response):
+        return response
+
+    orig_request = response.request
+    location = response.headers[HEADER_LOCATION]
+
+    while True:
+        poll = client.request(
+            cast_to=httpx.Response,
+            options=FinalRequestOptions.construct(
+                method="get",
+                url=location,
+                headers={HEADER_PREFER: omit},
+            ),
+        )
+        if resp := _resolve_poll_response(poll, orig_request):
+            return resp
+
+        time.sleep(POLL_INTERVAL_SECS)
+
+
+async def process_response_aio(*, response: httpx.Response, client: AsyncAPIClient) -> httpx.Response:
+    if not _respond_async_applied(response):
+        return response
+
+    orig_request = response.request
+    location = response.headers[HEADER_LOCATION]
+
+    while True:
+        poll = await client.request(
+            cast_to=httpx.Response,
+            options=FinalRequestOptions.construct(
+                method="get",
+                url=location,
+                headers={HEADER_PREFER: omit},
+            ),
+        )
+        if resp := _resolve_poll_response(poll, orig_request):
+            return resp
+
+        await anyio.sleep(POLL_INTERVAL_SECS)
+
+
+def _respond_async_applied(response: httpx.Response) -> bool:
+    if response.status_code != 202:
+        return False
+    applied = response.headers.get(HEADER_PREFERENCE_APPLIED, "")
+    return bool(applied.strip().lower() == RESPOND_ASYNC)
+
+
+class _PollError(BaseModel):
+    status_code: int
+    detail: Any = None
+
+
+class _PollResult(BaseModel):
+    success: Any = None
+    error: Optional[_PollError] = None
+
+
+class _PollBody(BaseModel):
+    status: Literal["running", "finished"]
+    result: Optional[_PollResult] = None
+
+
+def _resolve_poll_response(response: httpx.Response, request: httpx.Request) -> httpx.Response | None:
+    try:
+        body = parse_obj(_PollBody, response.json())
+        if body.status == "running":
+            return None
+        if body.result is None:
+            raise ValueError("missing 'result' field")
+        if (body.result.success is None) == (body.result.error is None):
+            raise ValueError("'result' must have exactly one of 'success'/'error'")
+    except (pydantic.ValidationError, ValueError) as err:
+        raise APIResponseValidationError(
+            response=response, body=response.text, message=f"malformed poll response: {err}"
+        ) from err
+
+    if body.result.success is not None:
+        return httpx.Response(
+            status_code=200,
+            json=body.result.success,
+            request=request,
+        )
+
+    assert body.result.error is not None
+    error = body.result.error
+    return httpx.Response(
+        status_code=error.status_code,
+        json=error.detail,
+        request=request,
+    )

--- a/tests/custom/test_respond_async.py
+++ b/tests/custom/test_respond_async.py
@@ -295,6 +295,46 @@ async def test_async_poll_transient_failure() -> None:
 
 
 @respx.mock
+def test_sync_poll_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(respond_async, "POLL_INTERVAL_SECS", 0.01)
+
+    poll_url = f"{base_url}/v1/namespaces/test/operations/op-slow"
+    respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(
+            202,
+            headers={"preference-applied": "respond-async", "location": poll_url},
+        )
+    )
+    respx.get(poll_url).mock(return_value=httpx.Response(200, json={"status": "running"}))
+
+    http_client = httpx.Client(transport=httpx.HTTPTransport())
+    client = Turbopuffer(base_url=base_url, api_key=api_key, http_client=http_client, timeout=0.05)
+
+    with pytest.raises(turbopuffer.APITimeoutError):
+        client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_poll_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(respond_async, "POLL_INTERVAL_SECS", 0.01)
+
+    poll_url = f"{base_url}/v1/namespaces/test/operations/op-slow"
+    respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(
+            202,
+            headers={"preference-applied": "respond-async", "location": poll_url},
+        )
+    )
+    respx.get(poll_url).mock(return_value=httpx.Response(200, json={"status": "running"}))
+
+    http_client = httpx.AsyncClient(transport=httpx.AsyncHTTPTransport())
+    async with AsyncTurbopuffer(base_url=base_url, api_key=api_key, http_client=http_client, timeout=0.05) as client:
+        with pytest.raises(turbopuffer.APITimeoutError):
+            await client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+
+@respx.mock
 def test_sync_poll_too_many_failures() -> None:
     poll_url = f"{base_url}/v1/namespaces/test/operations/op-dead"
     respx.post(f"{base_url}/v2/namespaces/test").mock(

--- a/tests/custom/test_respond_async.py
+++ b/tests/custom/test_respond_async.py
@@ -1,0 +1,336 @@
+import httpx
+import respx
+import pytest
+
+import turbopuffer
+from turbopuffer import Turbopuffer, AsyncTurbopuffer
+from tests.conftest import api_key, base_url
+from turbopuffer.lib import respond_async
+
+WRITE_OK_BODY = {
+    "billing": {
+        "billable_logical_bytes_written": 0,
+        "billable_logical_bytes_returned": 0,
+    },
+    "message": "OK",
+    "rows_affected": 1,
+    "status": "OK",
+}
+
+
+@pytest.fixture(autouse=True)
+def _no_poll_delay(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
+    monkeypatch.setattr(respond_async, "POLL_INTERVAL_SECS", 0)
+
+
+@respx.mock
+def test_sync_prefer_header_sent() -> None:
+    route = respx.post(f"{base_url}/v2/namespaces/test").mock(return_value=httpx.Response(200, json=WRITE_OK_BODY))
+
+    http_client = httpx.Client(transport=httpx.HTTPTransport())
+    client = Turbopuffer(base_url=base_url, api_key=api_key, http_client=http_client)
+    client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+    assert route.called
+    assert route.calls.last.request.headers.get("prefer") == "respond-async"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_prefer_header_sent() -> None:
+    route = respx.post(f"{base_url}/v2/namespaces/test").mock(return_value=httpx.Response(200, json=WRITE_OK_BODY))
+
+    http_client = httpx.AsyncClient(transport=httpx.AsyncHTTPTransport())
+    async with AsyncTurbopuffer(base_url=base_url, api_key=api_key, http_client=http_client) as client:
+        await client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+    assert route.called
+    assert route.calls.last.request.headers.get("prefer") == "respond-async"
+
+
+@respx.mock
+def test_sync_pass_through_sync_response() -> None:
+    route = respx.post(f"{base_url}/v2/namespaces/test").mock(return_value=httpx.Response(200, json=WRITE_OK_BODY))
+
+    http_client = httpx.Client(transport=httpx.HTTPTransport())
+    client = Turbopuffer(base_url=base_url, api_key=api_key, http_client=http_client)
+    resp = client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+    assert route.called
+    assert route.call_count == 1
+    assert resp.status == "OK"
+    assert resp.rows_affected == 1
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_pass_through_sync_response() -> None:
+    route = respx.post(f"{base_url}/v2/namespaces/test").mock(return_value=httpx.Response(200, json=WRITE_OK_BODY))
+
+    http_client = httpx.AsyncClient(transport=httpx.AsyncHTTPTransport())
+    async with AsyncTurbopuffer(base_url=base_url, api_key=api_key, http_client=http_client) as client:
+        resp = await client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+    assert route.called
+    assert route.call_count == 1
+    assert resp.status == "OK"
+    assert resp.rows_affected == 1
+
+
+@respx.mock
+def test_sync_async_applied_and_polled_to_success() -> None:
+    poll_url = f"{base_url}/v1/namespaces/test/operations/op-abc"
+    write_route = respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(
+            202,
+            headers={
+                "preference-applied": "respond-async",
+                "location": poll_url,
+            },
+        )
+    )
+    poll_route = respx.get(poll_url).mock(
+        side_effect=[
+            httpx.Response(200, json={"status": "running"}),
+            httpx.Response(200, json={"status": "running"}),
+            httpx.Response(
+                200,
+                json={"status": "finished", "result": {"success": WRITE_OK_BODY}},
+            ),
+        ]
+    )
+
+    http_client = httpx.Client(transport=httpx.HTTPTransport())
+    client = Turbopuffer(base_url=base_url, api_key=api_key, http_client=http_client)
+    resp = client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+    assert write_route.call_count == 1
+    assert poll_route.call_count == 3
+    assert resp.status == "OK"
+    # Auth headers should propagate to the poll request.
+    assert poll_route.calls.last.request.headers.get("authorization") is not None
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_async_applied_and_polled_to_success() -> None:
+    poll_url = f"{base_url}/v1/namespaces/test/operations/op-abc"
+    write_route = respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(
+            202,
+            headers={
+                "preference-applied": "respond-async",
+                "location": poll_url,
+            },
+        )
+    )
+    poll_route = respx.get(poll_url).mock(
+        side_effect=[
+            httpx.Response(200, json={"status": "running"}),
+            httpx.Response(200, json={"status": "running"}),
+            httpx.Response(
+                200,
+                json={"status": "finished", "result": {"success": WRITE_OK_BODY}},
+            ),
+        ]
+    )
+
+    http_client = httpx.AsyncClient(transport=httpx.AsyncHTTPTransport())
+    async with AsyncTurbopuffer(base_url=base_url, api_key=api_key, http_client=http_client) as client:
+        resp = await client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+    assert write_route.call_count == 1
+    assert poll_route.call_count == 3
+    assert resp.status == "OK"
+    # Auth headers should propagate to the poll request.
+    assert poll_route.calls.last.request.headers.get("authorization") is not None
+
+
+@respx.mock
+def test_sync_async_finished_with_error() -> None:
+    poll_url = f"{base_url}/v1/namespaces/test/operations/op-fail"
+    respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(
+            202,
+            headers={
+                "preference-applied": "respond-async",
+                "location": poll_url,
+            },
+        )
+    )
+    respx.get(poll_url).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "status": "finished",
+                "result": {"error": {"status_code": 404, "detail": {"message": "namespace not found"}}},
+            },
+        )
+    )
+
+    http_client = httpx.Client(transport=httpx.HTTPTransport())
+    client = Turbopuffer(base_url=base_url, api_key=api_key, http_client=http_client)
+
+    with pytest.raises(turbopuffer.NotFoundError) as excinfo:
+        client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+    assert "namespace not found" in str(excinfo.value)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_async_finished_with_error() -> None:
+    poll_url = f"{base_url}/v1/namespaces/test/operations/op-fail"
+    respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(
+            202,
+            headers={
+                "preference-applied": "respond-async",
+                "location": poll_url,
+            },
+        )
+    )
+    respx.get(poll_url).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "status": "finished",
+                "result": {"error": {"status_code": 404, "detail": {"message": "namespace not found"}}},
+            },
+        )
+    )
+
+    http_client = httpx.AsyncClient(transport=httpx.AsyncHTTPTransport())
+    async with AsyncTurbopuffer(base_url=base_url, api_key=api_key, http_client=http_client) as client:
+        with pytest.raises(turbopuffer.NotFoundError) as excinfo:
+            await client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+        assert "namespace not found" in str(excinfo.value)
+
+
+@respx.mock
+def test_sync_pass_through_unrelated_202() -> None:
+    route = respx.post(f"{base_url}/v2/namespaces/test").mock(return_value=httpx.Response(202, json=WRITE_OK_BODY))
+
+    http_client = httpx.Client(transport=httpx.HTTPTransport())
+    client = Turbopuffer(base_url=base_url, api_key=api_key, http_client=http_client)
+    resp = client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+    assert route.call_count == 1
+    assert resp.status == "OK"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_pass_through_unrelated_202() -> None:
+    route = respx.post(f"{base_url}/v2/namespaces/test").mock(return_value=httpx.Response(202, json=WRITE_OK_BODY))
+
+    http_client = httpx.AsyncClient(transport=httpx.AsyncHTTPTransport())
+    async with AsyncTurbopuffer(base_url=base_url, api_key=api_key, http_client=http_client) as client:
+        resp = await client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+    assert route.call_count == 1
+    assert resp.status == "OK"
+
+
+@respx.mock
+def test_sync_poll_transient_failure() -> None:
+    poll_url = f"{base_url}/v1/namespaces/test/operations/op-flaky"
+    respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(
+            202,
+            headers={
+                "preference-applied": "respond-async",
+                "location": poll_url,
+            },
+        )
+    )
+    poll_route = respx.get(poll_url).mock(
+        side_effect=[
+            httpx.Response(503),
+            httpx.Response(503),
+            httpx.Response(
+                200,
+                json={"status": "finished", "result": {"success": WRITE_OK_BODY}},
+            ),
+        ]
+    )
+
+    http_client = httpx.Client(transport=httpx.HTTPTransport())
+    client = Turbopuffer(base_url=base_url, api_key=api_key, http_client=http_client)
+    resp = client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+    assert poll_route.call_count == 3
+    assert resp.status == "OK"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_poll_transient_failure() -> None:
+    poll_url = f"{base_url}/v1/namespaces/test/operations/op-flaky"
+    respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(
+            202,
+            headers={
+                "preference-applied": "respond-async",
+                "location": poll_url,
+            },
+        )
+    )
+    poll_route = respx.get(poll_url).mock(
+        side_effect=[
+            httpx.Response(503),
+            httpx.Response(503),
+            httpx.Response(
+                200,
+                json={"status": "finished", "result": {"success": WRITE_OK_BODY}},
+            ),
+        ]
+    )
+
+    http_client = httpx.AsyncClient(transport=httpx.AsyncHTTPTransport())
+    async with AsyncTurbopuffer(base_url=base_url, api_key=api_key, http_client=http_client) as client:
+        resp = await client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+    assert poll_route.call_count == 3
+    assert resp.status == "OK"
+
+
+@respx.mock
+def test_sync_poll_too_many_failures() -> None:
+    poll_url = f"{base_url}/v1/namespaces/test/operations/op-dead"
+    respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(
+            202,
+            headers={
+                "preference-applied": "respond-async",
+                "location": poll_url,
+            },
+        )
+    )
+    respx.get(poll_url).mock(return_value=httpx.Response(503))
+
+    http_client = httpx.Client(transport=httpx.HTTPTransport())
+    client = Turbopuffer(base_url=base_url, api_key=api_key, http_client=http_client, max_retries=0)
+
+    with pytest.raises(turbopuffer.InternalServerError):
+        client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_poll_too_many_failures() -> None:
+    poll_url = f"{base_url}/v1/namespaces/test/operations/op-dead"
+    respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(
+            202,
+            headers={
+                "preference-applied": "respond-async",
+                "location": poll_url,
+            },
+        )
+    )
+    respx.get(poll_url).mock(return_value=httpx.Response(503))
+
+    http_client = httpx.AsyncClient(transport=httpx.AsyncHTTPTransport())
+    async with AsyncTurbopuffer(base_url=base_url, api_key=api_key, http_client=http_client, max_retries=0) as client:
+        with pytest.raises(turbopuffer.InternalServerError):
+            await client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})


### PR DESCRIPTION
This adds support for transparent async polling against tpuf APIs that support it. The SDK unconditionally set the `prefer: respond-async` header on all API calls, then detects and handles async responses by polling them until the final state.

# Example

This is an example exercising both the clients. Runs against a local tpuf listening on port 3001.

```python
import asyncio
import logging

from turbopuffer import AsyncTurbopuffer, Turbopuffer

logging.basicConfig(
    level=logging.INFO,
    format="%(asctime)s.%(msecs)03d  %(message)s",
    datefmt="%H:%M:%S",
)

API_KEY = "..."
BASE_URL = "http://localhost:3001"
NAMESPACE = "respond-async-smoke"

UPSERT_COLUMNS = {
    "id": [1, 2, 3, 4, 5],
    "vector": [[0.1, 0.2], [0.2, 0.1], [0.3, 0.3], [0.4, 0.1], [0.5, 0.2]],
}


def run_sync() -> None:
    client = Turbopuffer(api_key=API_KEY, base_url=BASE_URL)
    ns = client.namespace(NAMESPACE)

    print("\n=== [sync] seeding namespace ===")
    ns.write(upsert_columns=UPSERT_COLUMNS, distance_metric="euclidean_squared")

    print("\n=== [sync] calling recall (expect 202 + polling cycle) ===")
    result = ns.recall(num=2, top_k=3)

    print("\n=== [sync] final recall result ===")
    print(result)


async def run_async() -> None:
    async with AsyncTurbopuffer(api_key=API_KEY, base_url=BASE_URL) as client:
        ns = client.namespace(NAMESPACE)

        print("\n=== [async] seeding namespace ===")
        await ns.write(upsert_columns=UPSERT_COLUMNS, distance_metric="euclidean_squared")

        print("\n=== [async] calling recall (expect 202 + polling cycle) ===")
        result = await ns.recall(num=2, top_k=3)

        print("\n=== [async] final recall result ===")
        print(result)


run_sync()
asyncio.run(run_async())
```

Output on my machine:

```
=== [sync] seeding namespace ===
18:04:25.650  HTTP Request: POST http://localhost:3001/v2/namespaces/respond-async-smoke "HTTP/1.1 200 OK"

=== [sync] calling recall (expect 202 + polling cycle) ===
18:04:26.267  HTTP Request: POST http://localhost:3001/v1/namespaces/respond-async-smoke/_debug/recall "HTTP/1.1 202 Accepted"
18:04:26.419  HTTP Request: GET http://localhost:3001/v1/namespaces/respond-async-smoke/operations/tpuf-job-rec-019e36ae-7db4-7df9-b084-5de72f231329 "HTTP/1.1 200 OK"
18:04:27.580  HTTP Request: GET http://localhost:3001/v1/namespaces/respond-async-smoke/operations/tpuf-job-rec-019e36ae-7db4-7df9-b084-5de72f231329 "HTTP/1.1 200 OK"
18:04:28.734  HTTP Request: GET http://localhost:3001/v1/namespaces/respond-async-smoke/operations/tpuf-job-rec-019e36ae-7db4-7df9-b084-5de72f231329 "HTTP/1.1 200 OK"

=== [sync] final recall result ===
NamespaceRecallResponse(avg_ann_count=3.0, avg_exhaustive_count=3.0, avg_recall=1.0, ground_truth=None)

=== [async] seeding namespace ===
18:04:30.413  HTTP Request: POST http://localhost:3001/v2/namespaces/respond-async-smoke "HTTP/1.1 200 OK"

=== [async] calling recall (expect 202 + polling cycle) ===
18:04:31.353  HTTP Request: POST http://localhost:3001/v1/namespaces/respond-async-smoke/_debug/recall "HTTP/1.1 202 Accepted"
18:04:31.513  HTTP Request: GET http://localhost:3001/v1/namespaces/respond-async-smoke/operations/tpuf-job-rec-019e36ae-904e-7aa2-a75b-8524076ea152 "HTTP/1.1 200 OK"
18:04:32.670  HTTP Request: GET http://localhost:3001/v1/namespaces/respond-async-smoke/operations/tpuf-job-rec-019e36ae-904e-7aa2-a75b-8524076ea152 "HTTP/1.1 200 OK"
18:04:33.820  HTTP Request: GET http://localhost:3001/v1/namespaces/respond-async-smoke/operations/tpuf-job-rec-019e36ae-904e-7aa2-a75b-8524076ea152 "HTTP/1.1 200 OK"
18:04:35.034  HTTP Request: GET http://localhost:3001/v1/namespaces/respond-async-smoke/operations/tpuf-job-rec-019e36ae-904e-7aa2-a75b-8524076ea152 "HTTP/1.1 200 OK"

=== [async] final recall result ===
NamespaceRecallResponse(avg_ann_count=3.0, avg_exhaustive_count=3.0, avg_recall=1.0, ground_truth=None)
```