### PR TITLE
fix: exception type on missing respond-async Location header

### DIFF
--- a/src/turbopuffer/lib/respond_async.py
+++ b/src/turbopuffer/lib/respond_async.py
@@ -56,7 +56,7 @@ def process_response(
         return response
 
     orig_request = response.request
-    location = response.headers[HEADER_LOCATION]
+    location = _extract_location(response)
     timeout = _Timeout(options, client.timeout)
 
     while True:
@@ -88,7 +88,7 @@ async def process_response_aio(
         return response
 
     orig_request = response.request
-    location = response.headers[HEADER_LOCATION]
+    location = _extract_location(response)
     timeout = _Timeout(options, client.timeout)
 
     while True:
@@ -115,6 +115,17 @@ def _respond_async_applied(response: httpx.Response) -> bool:
         return False
     applied = response.headers.get(HEADER_PREFERENCE_APPLIED, "")
     return bool(applied.strip().lower() == RESPOND_ASYNC)
+
+
+def _extract_location(response: httpx.Response) -> str:
+    location: str = response.headers.get(HEADER_LOCATION, "").strip()
+    if not location:
+        raise APIResponseValidationError(
+            response=response,
+            body=response.text,
+            message="missing 'Location' header on respond-async response",
+        )
+    return location
 
 
 class _PollError(BaseModel):

--- a/tests/custom/test_respond_async.py
+++ b/tests/custom/test_respond_async.py
@@ -335,6 +335,32 @@ async def test_async_poll_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @respx.mock
+def test_sync_async_applied_missing_location_header() -> None:
+    respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(202, headers={"preference-applied": "respond-async"})
+    )
+
+    http_client = httpx.Client(transport=httpx.HTTPTransport())
+    client = Turbopuffer(base_url=base_url, api_key=api_key, http_client=http_client)
+
+    with pytest.raises(turbopuffer.APIResponseValidationError):
+        client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_async_applied_missing_location_header() -> None:
+    respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(202, headers={"preference-applied": "respond-async"})
+    )
+
+    http_client = httpx.AsyncClient(transport=httpx.AsyncHTTPTransport())
+    async with AsyncTurbopuffer(base_url=base_url, api_key=api_key, http_client=http_client) as client:
+        with pytest.raises(turbopuffer.APIResponseValidationError):
+            await client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+
+@respx.mock
 def test_sync_poll_too_many_failures() -> None:
     poll_url = f"{base_url}/v1/namespaces/test/operations/op-dead"
     respx.post(f"{base_url}/v2/namespaces/test").mock(


### PR DESCRIPTION
If a respond-async response misses the Location header, that should raise a proper SDK error, not `KeyError`.

[Found by bugbot on the release PR.](https://github.com/turbopuffer/turbopuffer-python/pull/232#discussion_r3295400387)