### PR TITLE
fix: reject malicious poll locations

### DIFF
--- a/src/turbopuffer/lib/respond_async.py
+++ b/src/turbopuffer/lib/respond_async.py
@@ -118,14 +118,33 @@ def _respond_async_applied(response: httpx.Response) -> bool:
 
 
 def _extract_location(response: httpx.Response) -> str:
-    location: str = response.headers.get(HEADER_LOCATION, "").strip()
-    if not location:
+    raw_location: str = response.headers.get(HEADER_LOCATION, "").strip()
+    if not raw_location:
         raise APIResponseValidationError(
             response=response,
             body=response.text,
             message="missing 'Location' header on respond-async response",
         )
-    return location
+
+    orig = response.request.url
+    try:
+        # Resolve the Location against the original request URL.
+        location = orig.join(raw_location)
+    except httpx.InvalidURL as err:
+        raise APIResponseValidationError(
+            response=response,
+            body=response.text,
+            message=f"malformed 'Location' header: {raw_location!r}",
+        ) from err
+
+    # Reject a Location pointing at a different origin, to prevent API key exfiltration.
+    if (location.scheme, location.host, location.port) != (orig.scheme, orig.host, orig.port):
+        raise APIResponseValidationError(
+            response=response,
+            body=response.text,
+            message=f"'Location' origin does not match request origin: {raw_location!r}",
+        )
+    return str(location)
 
 
 class _PollError(BaseModel):

--- a/tests/custom/test_respond_async.py
+++ b/tests/custom/test_respond_async.py
@@ -360,6 +360,45 @@ async def test_async_async_applied_missing_location_header() -> None:
             await client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
 
 
+BAD_LOCATIONS = [
+    "https://evil.example.com/v1/ops/op-x",
+    "//evil.example.com/v1/ops/op-x",
+    "http://api.turbopuffer.com/v1/ops/op-x",
+    "http://host:notaport/x",
+]
+
+
+@respx.mock
+@pytest.mark.parametrize("bad_location", BAD_LOCATIONS)
+def test_sync_async_applied_bad_location(bad_location: str) -> None:
+    respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(
+            202,
+            headers={"preference-applied": "respond-async", "location": bad_location},
+        )
+    )
+    http_client = httpx.Client(transport=httpx.HTTPTransport())
+    client = Turbopuffer(base_url=base_url, api_key=api_key, http_client=http_client)
+    with pytest.raises(turbopuffer.APIResponseValidationError):
+        client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+
+@respx.mock
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_location", BAD_LOCATIONS)
+async def test_async_async_applied_bad_location(bad_location: str) -> None:
+    respx.post(f"{base_url}/v2/namespaces/test").mock(
+        return_value=httpx.Response(
+            202,
+            headers={"preference-applied": "respond-async", "location": bad_location},
+        )
+    )
+    http_client = httpx.AsyncClient(transport=httpx.AsyncHTTPTransport())
+    async with AsyncTurbopuffer(base_url=base_url, api_key=api_key, http_client=http_client) as client:
+        with pytest.raises(turbopuffer.APIResponseValidationError):
+            await client.namespace("test").write(upsert_columns={"id": [1], "vector": [[0.1]]})
+
+
 @respx.mock
 def test_sync_poll_too_many_failures() -> None:
     poll_url = f"{base_url}/v1/namespaces/test/operations/op-dead"


### PR DESCRIPTION
This fixes a minor security issue where the client wouldn't check the origin of the async response `Location` header before starting to poll it, allowing a man-in-the-middle to send poll requests (including API credentials) to arbitrary locations. This is a minor security issue, as such a man-in-the-middle would likely already know the API credentials from observing the initial authenticated request.

The fix is to compare the poll origin with the one from the original request, and reject if they differ.