### PR TITLE
fix: type rerank_by parameter as RerankBy

### DIFF
--- a/src/turbopuffer/resources/namespaces.py
+++ b/src/turbopuffer/resources/namespaces.py
@@ -33,7 +33,7 @@ from .._response import (
 )
 from .._exceptions import NotFoundError
 from .._base_client import make_request_options
-from ..types.custom import Filter, RankBy, GroupBy, AggregateBy
+from ..types.custom import Filter, RankBy, GroupBy, RerankBy, AggregateBy
 from ..types.id_param import IDParam
 from ..types.row_param import RowParam
 from ..types.columns_param import ColumnsParam
@@ -376,7 +376,7 @@ class NamespacesResource(SyncAPIResource):
         namespace: str | None = None,
         queries: Iterable[namespace_multi_query_params.Query],
         consistency: namespace_multi_query_params.Consistency | Omit = omit,
-        rerank_by: object | Omit = omit,
+        rerank_by: RerankBy | Omit = omit,
         vector_encoding: VectorEncoding | Omit = omit,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
@@ -1135,7 +1135,7 @@ class AsyncNamespacesResource(AsyncAPIResource):
         namespace: str | None = None,
         queries: Iterable[namespace_multi_query_params.Query],
         consistency: namespace_multi_query_params.Consistency | Omit = omit,
-        rerank_by: object | Omit = omit,
+        rerank_by: RerankBy | Omit = omit,
         vector_encoding: VectorEncoding | Omit = omit,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.

--- a/tests/api_resources/test_namespaces.py
+++ b/tests/api_resources/test_namespaces.py
@@ -299,7 +299,7 @@ class TestNamespaces:
                 }
             ],
             consistency={"level": "strong"},
-            rerank_by={},
+            rerank_by=("RRF",),
             vector_encoding="float",
         )
         assert_matches_type(NamespaceMultiQueryResponse, namespace, path=["response"])
@@ -918,7 +918,7 @@ class TestAsyncNamespaces:
                 }
             ],
             consistency={"level": "strong"},
-            rerank_by={},
+            rerank_by=("RRF",),
             vector_encoding="float",
         )
         assert_matches_type(NamespaceMultiQueryResponse, namespace, path=["response"])


### PR DESCRIPTION
## Summary
- Stainless leaves the `rerank_by` parameter typed as `object`. This wires it to the already-generated `RerankBy` type so callers get a proper signature.

## Test plan
- [x] Updated generated tests that previously passed `rerank_by={}` to a valid `("RRF",)` value
- [ ] Pyright/mypy run locally (couldn't run under sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)