### PR TITLE
chore: regenerate custom types for compute attributes

### DIFF
--- a/src/turbopuffer/types/custom.py
+++ b/src/turbopuffer/types/custom.py
@@ -2,18 +2,30 @@
 
 from typing import Any, Tuple, Union, Literal, Mapping, Sequence, TypedDict
 
+from .vector import Vector
 from .rrf_params import RrfParams
 from .decay_params import DecayParams
 from .embed_params import EmbedParams
 from .fuzzy_params import FuzzyParams
 from .saturate_params import SaturateParams
 from .bm25_clause_params import Bm25ClauseParams
+from .highlight_config_params import HighlightConfigParams
 from .contains_any_token_filter_params import ContainsAnyTokenFilterParams
 from .contains_all_tokens_filter_params import ContainsAllTokensFilterParams
 
 AggregateBy = Union[Tuple[Literal["Count"]], Tuple[Literal["Sum"], str], Tuple[Literal["Count"], str]]
+ComputeAttributesVectorDist = Tuple[str, Literal["VectorDist"], Vector]
+ComputeAttributesHighlight = Tuple[Literal["Highlight"], str]
+ComputeAttributesHighlightWithConfig = Tuple[Literal["Highlight"], str, HighlightConfigParams]
+RankByAnn = Tuple[str, Literal["ANN"], Sequence[float]]
+RankByAnnMulti = Tuple[str, Literal["ANN"], Sequence[Sequence[float]]]
 ExprRefNew = TypedDict("ExprRefNew", {"$ref_new": str})
 Expr = Union[ExprRefNew, Tuple[Literal["Embed"], str], Tuple[Literal["Embed"], str, EmbedParams]]
+RankByAnnExpr = Tuple[str, Literal["ANN"], Expr]
+RankByKnn = Tuple[str, Literal["kNN"], Sequence[float]]
+RankByKnnMulti = Tuple[str, Literal["kNN"], Sequence[Sequence[float]]]
+RankByKnnExpr = Tuple[str, Literal["kNN"], Expr]
+RankBySparseKnn = Tuple[str, Literal["SparseKNN"], Mapping[str, float]]
 Filter = Union[
     Tuple[str, Literal["Eq"], Any],
     Tuple[str, Literal["NotEq"], Any],
@@ -51,15 +63,6 @@ Filter = Union[
     Tuple[Literal["And"], Sequence["Filter"]],
     Tuple[Literal["Or"], Sequence["Filter"]],
 ]
-GroupByFunction = Tuple[Literal["ForEachUnique"], str]
-GroupBy = Union[str, Mapping[str, GroupByFunction]]
-RankByAnn = Tuple[str, Literal["ANN"], Sequence[float]]
-RankByAnnMulti = Tuple[str, Literal["ANN"], Sequence[Sequence[float]]]
-RankByAnnExpr = Tuple[str, Literal["ANN"], Expr]
-RankByKnn = Tuple[str, Literal["kNN"], Sequence[float]]
-RankByKnnMulti = Tuple[str, Literal["kNN"], Sequence[Sequence[float]]]
-RankByKnnExpr = Tuple[str, Literal["kNN"], Expr]
-RankBySparseKnn = Tuple[str, Literal["SparseKNN"], Mapping[str, float]]
 RankByText = Union[
     Tuple[str, Literal["BM25"], str],
     Tuple[str, Literal["BM25"], Sequence[str]],
@@ -90,4 +93,12 @@ RankBy = Union[
     RankByAttribute,
     RankByAttributes,
 ]
+ComputeAttributes = Union[
+    ComputeAttributesVectorDist,
+    ComputeAttributesHighlight,
+    ComputeAttributesHighlightWithConfig,
+    RankBy,
+]
+GroupByFunction = Tuple[Literal["ForEachUnique"], str]
+GroupBy = Union[str, Mapping[str, GroupByFunction]]
 RerankBy = Union[Tuple[Literal["RRF"]], Tuple[Literal["RRF"], RrfParams]]

--- a/tests/api_resources/test_namespaces.py
+++ b/tests/api_resources/test_namespaces.py
@@ -172,7 +172,7 @@ class TestNamespaces:
     @parametrize
     def test_method_explain_query_with_all_params(self, client: Turbopuffer) -> None:
         namespace = client.namespace("namespace").explain_query(
-            aggregate_by={"foo": "bar"},
+            aggregate_by={"foo": ("Sum", "bar")},
             compute_attributes={"foo": "bar"},
             consistency={"level": "strong"},
             distance_metric="cosine_distance",
@@ -359,7 +359,7 @@ class TestNamespaces:
     @parametrize
     def test_method_query_with_all_params(self, client: Turbopuffer) -> None:
         namespace = client.namespace("namespace").query(
-            aggregate_by={"foo": "bar"},
+            aggregate_by={"foo": ("Sum", "bar")},
             compute_attributes={"foo": "bar"},
             consistency={"level": "strong"},
             distance_metric="cosine_distance",
@@ -799,7 +799,7 @@ class TestAsyncNamespaces:
     @parametrize
     async def test_method_explain_query_with_all_params(self, async_client: AsyncTurbopuffer) -> None:
         namespace = await async_client.namespace("namespace").explain_query(
-            aggregate_by={"foo": "bar"},
+            aggregate_by={"foo": ("Sum", "bar")},
             compute_attributes={"foo": "bar"},
             consistency={"level": "strong"},
             distance_metric="cosine_distance",
@@ -989,7 +989,7 @@ class TestAsyncNamespaces:
     @parametrize
     async def test_method_query_with_all_params(self, async_client: AsyncTurbopuffer) -> None:
         namespace = await async_client.namespace("namespace").query(
-            aggregate_by={"foo": "bar"},
+            aggregate_by={"foo": ("Sum", "bar")},
             compute_attributes={"foo": "bar"},
             consistency={"level": "strong"},
             distance_metric="cosine_distance",


### PR DESCRIPTION
Lands the apigen-generated ComputeAttributes union into src/turbopuffer/types/custom.py.

The Regenerate Custom Types workflow regenerates this correctly but can't git push to next (ruleset requires a PR) — same PR path used for prior custom-code changes (e.g. rerank_by, #239). Depends on the HighlightConfig -> HighlightConfigParams rename (turbopuffer#10544), now on next.

Verified locally: ruff format + ruff check --fix applied (matches scripts/format), idempotent so the 'supplemental generated code out of date' lint passes; HighlightConfigParams defined on next so refs resolve; syntax valid.