### PR TITLE
spec: using typed version of `ComputeAttributes` for `compute_attributes`

### DIFF
--- a/src/turbopuffer/types/custom.py
+++ b/src/turbopuffer/types/custom.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Tuple, Union, Literal, Mapping, Sequence, TypedDict
 
-from .vector import Vector
 from .rrf_params import RrfParams
 from .decay_params import DecayParams
 from .embed_params import EmbedParams
@@ -14,7 +13,7 @@ from .contains_any_token_filter_params import ContainsAnyTokenFilterParams
 from .contains_all_tokens_filter_params import ContainsAllTokensFilterParams
 
 AggregateBy = Union[Tuple[Literal["Count"]], Tuple[Literal["Sum"], str], Tuple[Literal["Count"], str]]
-ComputeAttributesVectorDist = Tuple[str, Literal["VectorDist"], Vector]
+ComputeAttributesVectorDist = Tuple[str, Literal["VectorDist"], Sequence[float]]
 ComputeAttributesHighlight = Tuple[Literal["Highlight"], str]
 ComputeAttributesHighlightWithConfig = Tuple[Literal["Highlight"], str, HighlightConfigParams]
 RankByAnn = Tuple[str, Literal["ANN"], Sequence[float]]

--- a/src/turbopuffer/types/namespace_explain_query_params.py
+++ b/src/turbopuffer/types/namespace_explain_query_params.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Union, Iterable
 from typing_extensions import Literal, TypeAlias, TypedDict
 
-from .custom import GroupBy
+from .custom import GroupBy, ComputeAttributes
 from .._types import SequenceNotStr
 from .limit_param import LimitParam
 from .distance_metric import DistanceMetric
@@ -24,7 +24,7 @@ class NamespaceExplainQueryParams(TypedDict, total=False):
     filters.
     """
 
-    compute_attributes: Dict[str, object]
+    compute_attributes: Dict[str, ComputeAttributes]
     """Computes additional values on documents returned by a query.
 
     Each key is the name of the computed attribute; each value is an expression

--- a/src/turbopuffer/types/namespace_multi_query_params.py
+++ b/src/turbopuffer/types/namespace_multi_query_params.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Union, Iterable
 from typing_extensions import Literal, Required, TypeAlias, TypedDict
 
-from .custom import GroupBy
+from .custom import GroupBy, ComputeAttributes
 from .._types import SequenceNotStr
 from .limit_param import LimitParam
 from .distance_metric import DistanceMetric
@@ -42,7 +42,7 @@ class Query(TypedDict, total=False):
     filters.
     """
 
-    compute_attributes: Dict[str, object]
+    compute_attributes: Dict[str, ComputeAttributes]
     """Computes additional values on documents returned by a query.
 
     Each key is the name of the computed attribute; each value is an expression

--- a/src/turbopuffer/types/namespace_query_params.py
+++ b/src/turbopuffer/types/namespace_query_params.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Union, Iterable
 from typing_extensions import Literal, TypeAlias, TypedDict
 
-from .custom import Filter, GroupBy, AggregateBy
+from .custom import Filter, GroupBy, AggregateBy, ComputeAttributes
 from .._types import SequenceNotStr
 from .limit_param import LimitParam
 from .distance_metric import DistanceMetric
@@ -24,7 +24,7 @@ class NamespaceQueryParams(TypedDict, total=False):
     filters.
     """
 
-    compute_attributes: Dict[str, object]
+    compute_attributes: Dict[str, ComputeAttributes]
     """Computes additional values on documents returned by a query.
 
     Each key is the name of the computed attribute; each value is an expression

--- a/tests/api_resources/test_namespaces.py
+++ b/tests/api_resources/test_namespaces.py
@@ -173,7 +173,7 @@ class TestNamespaces:
     def test_method_explain_query_with_all_params(self, client: Turbopuffer) -> None:
         namespace = client.namespace("namespace").explain_query(
             aggregate_by={"foo": ("Sum", "bar")},
-            compute_attributes={"foo": "bar"},
+            compute_attributes={"foo": ("Highlight", "bar")},
             consistency={"level": "strong"},
             distance_metric="cosine_distance",
             exclude_attributes=["string"],
@@ -297,7 +297,7 @@ class TestNamespaces:
             queries=[
                 {
                     "aggregate_by": {"foo": "bar"},
-                    "compute_attributes": {"foo": "bar"},
+                    "compute_attributes": {"foo": ("Highlight", "bar")},
                     "distance_metric": "cosine_distance",
                     "exclude_attributes": ["string"],
                     "include_attributes": True,
@@ -360,7 +360,7 @@ class TestNamespaces:
     def test_method_query_with_all_params(self, client: Turbopuffer) -> None:
         namespace = client.namespace("namespace").query(
             aggregate_by={"foo": ("Sum", "bar")},
-            compute_attributes={"foo": "bar"},
+            compute_attributes={"foo": ("Highlight", "bar")},
             consistency={"level": "strong"},
             distance_metric="cosine_distance",
             exclude_attributes=["string"],
@@ -800,7 +800,7 @@ class TestAsyncNamespaces:
     async def test_method_explain_query_with_all_params(self, async_client: AsyncTurbopuffer) -> None:
         namespace = await async_client.namespace("namespace").explain_query(
             aggregate_by={"foo": ("Sum", "bar")},
-            compute_attributes={"foo": "bar"},
+            compute_attributes={"foo": ("Highlight", "bar")},
             consistency={"level": "strong"},
             distance_metric="cosine_distance",
             exclude_attributes=["string"],
@@ -927,7 +927,7 @@ class TestAsyncNamespaces:
             queries=[
                 {
                     "aggregate_by": {"foo": "bar"},
-                    "compute_attributes": {"foo": "bar"},
+                    "compute_attributes": {"foo": ("Highlight", "bar")},
                     "distance_metric": "cosine_distance",
                     "exclude_attributes": ["string"],
                     "include_attributes": True,
@@ -990,7 +990,7 @@ class TestAsyncNamespaces:
     async def test_method_query_with_all_params(self, async_client: AsyncTurbopuffer) -> None:
         namespace = await async_client.namespace("namespace").query(
             aggregate_by={"foo": ("Sum", "bar")},
-            compute_attributes={"foo": "bar"},
+            compute_attributes={"foo": ("Highlight", "bar")},
             consistency={"level": "strong"},
             distance_metric="cosine_distance",
             exclude_attributes=["string"],

--- a/tests/test_compute_attributes.py
+++ b/tests/test_compute_attributes.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Tuple, cast
+
+import pytest
+
+from turbopuffer.types import ComputeAttributes, NamespaceQueryParams
+from turbopuffer._utils import maybe_transform
+from turbopuffer.types.highlight_config_params import HighlightConfigParams
+
+# An empty HighlightConfigParams (all fields optional) is valid for the
+# HighlightWithConfig variant. Annotate it so it unifies with the union.
+_empty_highlight_config: HighlightConfigParams = {}
+
+# Each case: (variant name, ComputeAttributes value, expected JSON wire form).
+#
+# ComputeAttributes = Union[
+#     ComputeAttributesVectorDist,           # ("vec", "VectorDist", [0.5])
+#     ComputeAttributesHighlight,            # ("Highlight", "body")
+#     ComputeAttributesHighlightWithConfig,  # ("Highlight", "body", {})  (3rd elem is HighlightConfigParams)
+#     RankBy,                                # e.g. ("vec", "ANN", [0.5])
+# ]
+#
+# The variants are positional tuples that serialize to JSON arrays on the wire.
+CASES: List[Tuple[str, ComputeAttributes, List[Any]]] = [
+    ("VectorDist", ("vec", "VectorDist", [0.5]), ["vec", "VectorDist", [0.5]]),
+    ("Highlight", ("Highlight", "body"), ["Highlight", "body"]),
+    ("HighlightWithConfig", ("Highlight", "body", _empty_highlight_config), ["Highlight", "body", {}]),
+    ("RankBy", ("vec", "ANN", [0.5]), ["vec", "ANN", [0.5]]),
+]
+
+
+@pytest.mark.parametrize(("variant", "value", "expected_wire"), CASES)
+def test_compute_attributes_serialization(variant: str, value: ComputeAttributes, expected_wire: List[Any]) -> None:
+    """Every variant of the ComputeAttributes union serializes to its expected wire form."""
+    body: NamespaceQueryParams = {
+        "compute_attributes": {"my_attr": value},
+        "top_k": 10,
+    }
+
+    transformed = cast(Dict[str, Any], maybe_transform(body, NamespaceQueryParams))
+    serialized = transformed["compute_attributes"]["my_attr"]
+
+    # The wire form is JSON, where tuples become arrays. Round-trip through JSON
+    # to normalize tuples -> lists, then assert structural equality.
+    assert json.loads(json.dumps(serialized)) == expected_wire, (
+        f"variant {variant!r} serialized to {serialized!r}, expected {expected_wire!r}"
+    )


### PR DESCRIPTION
Wiring in the codegen `ComputeAttributes` type as stainless won't handle the custom type (from apigen) on its own.