### PR TITLE
tests: accept new rank_by error message format

### DIFF
--- a/tests/custom/test_bm25.py
+++ b/tests/custom/test_bm25.py
@@ -257,7 +257,7 @@ def test_bm25_pre_tokenized_array(tpuf: Turbopuffer):
     assert len(result.rows) == 2
 
     with pytest.raises(
-        turbopuffer.APIError, match=r"""invalid input \\'jumped\\' for rank_by field "content", expecting \[\]string"""
+        turbopuffer.APIError, match=r"""invalid input .* for rank_by field "content", expecting \[\]string"""
     ):
         # Query must be an array.
         ns.query(


### PR DESCRIPTION
The server is being changed to no longer echo attribute values in error messages: the invalid rank_by input error now reports the input's *type* instead of its value. Relax the assertion in `test_bm25_pre_tokenized_array` to match both formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)