### PR TITLE
feat: type compute_attributes as the Expr union (turbopuffer#10694)

### DIFF
--- a/scripts/gen
+++ b/scripts/gen
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-apigen_image=ghcr.io/turbopuffer/turbopuffer-apigen:50f6977f4020491663b87ecfc2650cc737f03437
+apigen_image=ghcr.io/turbopuffer/turbopuffer-apigen:e4acd3a33f47b226852188b8c76758333cf7fe51
 
 apigen() {
     if [[ "$TURBOPUFFER_DEV_APIGEN" ]]; then

--- a/src/turbopuffer/types/custom.py
+++ b/src/turbopuffer/types/custom.py
@@ -13,17 +13,16 @@ from .contains_any_token_filter_params import ContainsAnyTokenFilterParams
 from .contains_all_tokens_filter_params import ContainsAllTokensFilterParams
 
 AggregateBy = Union[Tuple[Literal["Count"]], Tuple[Literal["Sum"], str], Tuple[Literal["Count"], str]]
-ComputeAttributesVectorDist = Tuple[str, Literal["VectorDist"], Sequence[float]]
-ComputeAttributesHighlight = Tuple[Literal["Highlight"], str]
-ComputeAttributesHighlightWithConfig = Tuple[Literal["Highlight"], str, HighlightConfigParams]
+ExprRefNew = TypedDict("ExprRefNew", {"$ref_new": str})
+ExprVectorDist = Tuple[str, Literal["VectorDist"], Sequence[float]]
+ExprHighlight = Tuple[Literal["Highlight"], str]
+ExprHighlightWithConfig = Tuple[Literal["Highlight"], str, HighlightConfigParams]
 RankByAnn = Tuple[str, Literal["ANN"], Sequence[float]]
 RankByAnnMulti = Tuple[str, Literal["ANN"], Sequence[Sequence[float]]]
-ExprRefNew = TypedDict("ExprRefNew", {"$ref_new": str})
-Expr = Union[ExprRefNew, Tuple[Literal["Embed"], str], Tuple[Literal["Embed"], str, EmbedParams]]
-RankByAnnExpr = Tuple[str, Literal["ANN"], Expr]
+RankByAnnExpr = Tuple[str, Literal["ANN"], "Expr"]
 RankByKnn = Tuple[str, Literal["kNN"], Sequence[float]]
 RankByKnnMulti = Tuple[str, Literal["kNN"], Sequence[Sequence[float]]]
-RankByKnnExpr = Tuple[str, Literal["kNN"], Expr]
+RankByKnnExpr = Tuple[str, Literal["kNN"], "Expr"]
 RankBySparseKnn = Tuple[str, Literal["SparseKNN"], Mapping[str, float]]
 Filter = Union[
     Tuple[str, Literal["Eq"], Any],
@@ -92,10 +91,13 @@ RankBy = Union[
     RankByAttribute,
     RankByAttributes,
 ]
-ComputeAttributes = Union[
-    ComputeAttributesVectorDist,
-    ComputeAttributesHighlight,
-    ComputeAttributesHighlightWithConfig,
+Expr = Union[
+    ExprRefNew,
+    Tuple[Literal["Embed"], str],
+    Tuple[Literal["Embed"], str, EmbedParams],
+    ExprVectorDist,
+    ExprHighlight,
+    ExprHighlightWithConfig,
     RankBy,
 ]
 GroupByFunction = Tuple[Literal["ForEachUnique"], str]

--- a/src/turbopuffer/types/namespace_explain_query_params.py
+++ b/src/turbopuffer/types/namespace_explain_query_params.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Union, Iterable
 from typing_extensions import Literal, TypeAlias, TypedDict
 
-from .custom import GroupBy, ComputeAttributes
+from .custom import Expr, GroupBy
 from .._types import SequenceNotStr
 from .limit_param import LimitParam
 from .distance_metric import DistanceMetric
@@ -24,7 +24,7 @@ class NamespaceExplainQueryParams(TypedDict, total=False):
     filters.
     """
 
-    compute_attributes: Dict[str, ComputeAttributes]
+    compute_attributes: Dict[str, Expr]
     """Computes additional values on documents returned by a query.
 
     Each key is the name of the computed attribute; each value is an expression

--- a/src/turbopuffer/types/namespace_multi_query_params.py
+++ b/src/turbopuffer/types/namespace_multi_query_params.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Union, Iterable
 from typing_extensions import Literal, Required, TypeAlias, TypedDict
 
-from .custom import GroupBy, ComputeAttributes
+from .custom import Expr, GroupBy
 from .._types import SequenceNotStr
 from .limit_param import LimitParam
 from .distance_metric import DistanceMetric
@@ -42,7 +42,7 @@ class Query(TypedDict, total=False):
     filters.
     """
 
-    compute_attributes: Dict[str, ComputeAttributes]
+    compute_attributes: Dict[str, Expr]
     """Computes additional values on documents returned by a query.
 
     Each key is the name of the computed attribute; each value is an expression

--- a/src/turbopuffer/types/namespace_query_params.py
+++ b/src/turbopuffer/types/namespace_query_params.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Union, Iterable
 from typing_extensions import Literal, TypeAlias, TypedDict
 
-from .custom import Filter, GroupBy, AggregateBy, ComputeAttributes
+from .custom import Expr, Filter, GroupBy, AggregateBy
 from .._types import SequenceNotStr
 from .limit_param import LimitParam
 from .distance_metric import DistanceMetric
@@ -24,7 +24,7 @@ class NamespaceQueryParams(TypedDict, total=False):
     filters.
     """
 
-    compute_attributes: Dict[str, ComputeAttributes]
+    compute_attributes: Dict[str, Expr]
     """Computes additional values on documents returned by a query.
 
     Each key is the name of the computed attribute; each value is an expression


### PR DESCRIPTION
Follows spec turbopuffer/turbopuffer#10694 (merged) and depends on turbopuffer-apigen#18 (merged).

**Commit 1 (automated codegen):** bump the apigen image pin (`50f6977` → `e4acd3a`, which adds forward-ref quoting) and `scripts/gen` — apigen folds `ComputeAttributes` into the `Expr` union in `custom.py`. The `Expr`↔`RankBy` cycle now emits quoted forward refs (`Tuple[str, Literal["ANN"], "Expr"]`) so the module imports (Python evaluates type-alias assignments eagerly).
**Commit 2 (hand-rolled):** retarget `compute_attributes` in the 3 query-param models from the removed `ComputeAttributes` → `Expr`.

Verified locally: package imports cleanly, `scripts/gen` idempotent (gen-drift gate clean). Note: pre-existing pyright noise in `lib/transport_urllib3.py` is unrelated (none of the changed files are flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)