### PR TITLE
fix(client): thread all transport kwargs into the sync transport

### DIFF
--- a/src/turbopuffer/_base_client.py
+++ b/src/turbopuffer/_base_client.py
@@ -830,7 +830,19 @@ class _DefaultHttpxClient(httpx.Client):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
-        kwargs.setdefault("transport", HttpxTransport(limits=kwargs["limits"]))
+        # Mirrors httpx.Client._init_transport:
+        # https://github.com/encode/httpx/blob/0.28.1/httpx/_client.py#L718
+        kwargs.setdefault(
+            "transport",
+            HttpxTransport(
+                verify=kwargs.get("verify", True),
+                cert=kwargs.get("cert"),
+                trust_env=kwargs.get("trust_env", True),
+                http1=kwargs.get("http1", True),
+                http2=kwargs.get("http2", False),
+                limits=kwargs["limits"],
+            ),
+        )
         super().__init__(**kwargs)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import gc
 import os
+import ssl
 import sys
 import json
 import asyncio
@@ -1045,6 +1046,18 @@ class TestTurbopuffer:
         limits = httpx.Limits(max_connections=7, max_keepalive_connections=3, keepalive_expiry=1.0)
         pool = DefaultHttpxClient(limits=limits)._transport._pool  # type: ignore[attr-defined]
         assert (pool._max_connections, pool._max_keepalive_connections, pool._keepalive_expiry) == (7, 3, 1.0)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_default_client_honors_transport_kwargs(self) -> None:
+        # A custom transport causes httpx to ignore transport-construction
+        # kwargs (verify, cert, http1/http2, limits), so the default client
+        # must thread them into the transport itself. verify=False must reach
+        # the connection pool, otherwise TLS verification stays on despite the
+        # caller opting out.
+        pool = DefaultHttpxClient(verify=False)._transport._pool  # type: ignore[attr-defined]
+        assert pool._ssl_context.verify_mode == ssl.CERT_NONE  # pyright: ignore[reportUnknownMemberType]
+
+        pool = DefaultHttpxClient()._transport._pool  # type: ignore[attr-defined]
+        assert pool._ssl_context.verify_mode == ssl.CERT_REQUIRED  # pyright: ignore[reportUnknownMemberType]
 
     @pytest.mark.respx(base_url=base_url)
     def test_follow_redirects(self, respx_mock: MockRouter, client: Turbopuffer) -> None:


### PR DESCRIPTION
Supplying a custom transport makes httpx ignore every transport-construction kwarg, not just `limits`. As a result the default sync client silently dropped options like `verify` and `http2` when a caller set them. This threads them through so they take effect again, matching httpx's own transport construction.

Follow-up to #252, which fixed the same class of bug for `limits` only.